### PR TITLE
release: 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [1.2.0] - 2026-03-10
+## [1.2.0] - 2026-03-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,41 +9,22 @@ All notable changes to this project will be documented in this file.
 
 ## [1.2.0] - 2026-03-10
 
+### Added
+
+- **Alloy Role** - Resource limits (`alloy_max_memory`, `alloy_max_cpu`), external labels (`alloy_external_labels`), metric allowlist filtering (`alloy_node_exporter_metric_allowlist`), journal monitoring (`alloy_enable_journal_monitoring`, `alloy_journal_config`), and new argument specs (`alloy_default_queue_config`, `alloy_service_file`)
+- **DO Role** - Service config (`do_port`, `do_listen_address`, `do_storage_path`), feature flags (`do_enable_metrics`, `do_enable_logs`, `do_enable_insights`), Prometheus integration (`do_prometheus_enabled`, `do_prometheus_port`), and new argument_specs entries (`do_droplet_id`, `do_custom_config_enabled`)
+- **Tailscale Role** - `tailscale_version` added to argument_specs
+- **Developer Tooling** - `.ansible-lint`, security scanning configs (`.checkov.yml`, `.gitleaks.toml`, `.grype.yaml`, `.kics.json`, `.trivy.yaml`, `.secretlintrc.json`), code quality configs (`.jscpd.json`, `.markdown-link-check.json`, `.markdownlint.json`), `.pre-commit-config.yaml`, and `Makefile`
+
 ### Changed
 
-- **Alloy Role** - Updated Grafana Alloy to v1.14.0
-    - Added resource limits support (`alloy_max_memory`, `alloy_max_cpu`)
-    - Added external labels for all metrics and logs (`alloy_external_labels`)
-    - Added metric allowlist filtering (`alloy_node_exporter_metric_allowlist`)
-    - Added journal monitoring configuration (`alloy_enable_journal_monitoring`, `alloy_journal_config`)
-    - Added `alloy_default_queue_config` and `alloy_service_file` argument specs
-    - Updated `alloy_node_exporter_config` defaults with sensible production values
-    - Fixed argument_specs defaults for `alloy_version` and `alloy_node_exporter_config`
-- **DO Role** - Expanded configuration options
-    - Added service configuration: `do_port`, `do_listen_address`, `do_storage_path`
-    - Added feature flags: `do_enable_metrics`, `do_enable_logs`, `do_enable_insights`
-    - Added Prometheus integration: `do_prometheus_enabled`, `do_prometheus_port`
-    - Added `do_droplet_id` and `do_custom_config_enabled` to argument_specs
-    - Translated German comments to English in defaults
-    - Fixed argument_specs default for `do_version`
-- **Tailscale Role** - Improved argument specs
-    - Added `tailscale_version` to argument_specs
-    - Improved YAML formatting for systemd override defaults
-- **Developer Tooling** - Added comprehensive development and security tooling
-    - Added `.ansible-lint` configuration with exclude paths and skip/warn lists
-    - Added security scanning configs (`.checkov.yml`, `.gitleaks.toml`, `.grype.yaml`, `.kics.json`, `.trivy.yaml`, `.secretlintrc.json`)
-    - Added code quality configs (`.jscpd.json`, `.markdown-link-check.json`, `.markdownlint.json`)
-    - Added `.pre-commit-config.yaml` for local linting hooks
-    - Added `Makefile` for common development tasks
-    - Replaced `pytest.ini` with `pyproject.toml`
-    - Updated `.yamllint` and `.gitignore` configurations
-    - Streamlined `CONTRIBUTING.md`
+- **Alloy Role** - Updated Grafana Alloy to v1.14.0; updated `alloy_node_exporter_config` defaults with production values; fixed argument_specs defaults for `alloy_version` and `alloy_node_exporter_config`
+- **DO Role** - Translated German comments to English; fixed argument_specs default for `do_version`
+- **Tailscale Role** - Improved YAML formatting for systemd override defaults
+- **Developer Tooling** - Replaced `pytest.ini` with `pyproject.toml`; updated `.yamllint` and `.gitignore`; streamlined `CONTRIBUTING.md`
 - **CI/CD** - Restricted Claude review to newly opened pull requests
 - **Collection** - Added arillso as co-author in `galaxy.yml`
-- **Dependencies** - Updated development dependencies
-    - Updated molecule-plugins to v25
-    - Updated pytest-cov to v7
-    - Updated python dependencies
+- **Dependencies** - Updated molecule-plugins to v25, pytest-cov to v7, and python dependencies
 
 ## [1.1.0] - 2026-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-03-10
+
+### Changed
+
+- **Alloy Role** - Updated Grafana Alloy to v1.14.0
+    - Added resource limits support (`alloy_max_memory`, `alloy_max_cpu`)
+    - Added external labels for all metrics and logs (`alloy_external_labels`)
+    - Added metric allowlist filtering (`alloy_node_exporter_metric_allowlist`)
+    - Added journal monitoring configuration (`alloy_enable_journal_monitoring`, `alloy_journal_config`)
+    - Added `alloy_default_queue_config` and `alloy_service_file` argument specs
+    - Updated `alloy_node_exporter_config` defaults with sensible production values
+    - Fixed argument_specs defaults for `alloy_version` and `alloy_node_exporter_config`
+- **DO Role** - Expanded configuration options
+    - Added service configuration: `do_port`, `do_listen_address`, `do_storage_path`
+    - Added feature flags: `do_enable_metrics`, `do_enable_logs`, `do_enable_insights`
+    - Added Prometheus integration: `do_prometheus_enabled`, `do_prometheus_port`
+    - Added `do_droplet_id` and `do_custom_config_enabled` to argument_specs
+    - Translated German comments to English in defaults
+    - Fixed argument_specs default for `do_version`
+- **Tailscale Role** - Improved argument specs
+    - Added `tailscale_version` to argument_specs
+    - Improved YAML formatting for systemd override defaults
+- **Developer Tooling** - Added comprehensive development and security tooling
+    - Added `.ansible-lint` configuration with exclude paths and skip/warn lists
+    - Added security scanning configs (`.checkov.yml`, `.gitleaks.toml`, `.grype.yaml`, `.kics.json`, `.trivy.yaml`, `.secretlintrc.json`)
+    - Added code quality configs (`.jscpd.json`, `.markdown-link-check.json`, `.markdownlint.json`)
+    - Added `.pre-commit-config.yaml` for local linting hooks
+    - Added `Makefile` for common development tasks
+    - Replaced `pytest.ini` with `pyproject.toml`
+    - Updated `.yamllint` and `.gitignore` configurations
+    - Streamlined `CONTRIBUTING.md`
+- **CI/CD** - Restricted Claude review to newly opened pull requests
+- **Collection** - Added arillso as co-author in `galaxy.yml`
+- **Dependencies** - Updated development dependencies
+    - Updated molecule-plugins to v25
+    - Updated pytest-cov to v7
+    - Updated python dependencies
+
 ## [1.1.0] - 2026-03-08
 
 ### Changed
@@ -319,7 +357,8 @@ For detailed configuration examples, see the [Alloy role README](roles/alloy/REA
 
 See: <https://github.com/arillso/ansible.agent/releases>
 
-[Unreleased]: https://github.com/arillso/ansible.agent/compare/1.1.0...HEAD
+[Unreleased]: https://github.com/arillso/ansible.agent/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/arillso/ansible.agent/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/arillso/ansible.agent/compare/1.0.3...1.1.0
 [1.0.3]: https://github.com/arillso/ansible.agent/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/arillso/ansible.agent/compare/1.0.1...1.0.2

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: arillso
 name: agent
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.0
+version: 1.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
## Summary

- Bump collection version to `1.2.0` in `galaxy.yml`
- Update CHANGELOG.md for 1.2.0 release (Added/Changed sections)
- Fix release date to 2026-03-18

## Test plan

- [ ] CI passes
- [ ] Merge into main
- [ ] Tag `1.2.0` and push to trigger Galaxy publish