### PR TITLE
test(molecule): run alloy scenario on Debian 12 as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Molecule (CI)**: run the alloy scenario on Debian 12 in addition to
+  Ubuntu 22.04 (was Ubuntu-only), matching the two-distro coverage of the
+  do and tailscale scenarios.
+
+
 - Raise the Python target to `3.13` (the highest version `ansible-test`
   supports): bump `python_version` in `pull-request.yml` and `merge.yml` so CI
   exercises the same interpreter the release artifact is built with, matching

--- a/roles/alloy/molecule/default/molecule.yml
+++ b/roles/alloy/molecule/default/molecule.yml
@@ -20,6 +20,7 @@ platforms:
 
     - name: alloy-debian12
       image_url: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+      image_checksum: sha512:https://cloud.debian.org/images/cloud/bookworm/latest/SHA512SUMS
       image_arch: x86_64
       network_mode: user
       network_ssh_port: 2223

--- a/roles/alloy/molecule/default/molecule.yml
+++ b/roles/alloy/molecule/default/molecule.yml
@@ -18,6 +18,15 @@ platforms:
       vm_cpus: 2
       vm_memory: 2048
 
+    - name: alloy-debian12
+      image_url: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2223
+      network_ssh_user: debian
+      vm_cpus: 2
+      vm_memory: 2048
+
 provisioner:
     name: ansible
     config_options:
@@ -30,6 +39,9 @@ provisioner:
         host_vars:
             alloy-ubuntu2204:
                 # cloud images log in as `ubuntu`; the role needs root.
+                ansible_become: true
+            alloy-debian12:
+                # debian cloud images log in as `debian`; the role needs root.
                 ansible_become: true
 
 verifier:


### PR DESCRIPTION
## Summary

The alloy molecule scenario was reduced to a single Ubuntu 22.04 platform during the molecule-qemu/KVM switch (#86). Add a Debian 12 (bookworm) cloud-image platform so alloy runs on two distros, matching the do and tailscale scenarios.

## Test plan

- [ ] `molecule-alloy` green on ubuntu2204 + debian12