### PR TITLE
fix(agent): close molecule side_effect gap and align role metadata

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,10 @@
     "customManagers": [
         {
             "customType": "regex",
-            "managerFilePatterns": ["/^roles/.*/defaults/main\\.yml$/"],
+            "managerFilePatterns": [
+                "/^roles/.*/defaults/main\\.yml$/",
+                "/^roles/.*/meta/argument_specs\\.yml$/"
+            ],
             "matchStrings": [
                 "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+extractVersion=(?<extractVersion>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?\\s*(?:\\r?\\n|\\r).*?:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?\\s*(?:\\r?\\n|\\r|$)"
             ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Renovate**: the custom regex manager now also scans
+  `roles/*/meta/argument_specs.yml`, and the `*_version` defaults in the
+  `alloy`, `do`, and `tailscale` specs carry `# renovate:` comments, so future
+  upstream releases bump both `defaults/main.yml` and the argument spec in one
+  PR. The spec defaults had drifted because nothing tracked them — realigned
+  `do_version` (`3.18.8` → `3.18.14`) and `tailscale_version`
+  (`1.94.2` → `1.98.5`) to match `defaults/main.yml`.
+
 - **Molecule (CI)**: run the alloy scenario on Debian 12 in addition to
   Ubuntu 22.04 (was Ubuntu-only), matching the two-distro coverage of the
   do and tailscale scenarios.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Molecule (all roles)**: add the missing `side_effect.yml` play to the
+  `alloy`, `do`, and `tailscale` default scenarios. Their `test_sequence`
+  referenced a `side_effect` step with no matching file, so `molecule test`
+  failed before reaching `verify`.
+- **Alloy argument_specs**: align the `alloy_version` default (`1.13.2`) with
+  `defaults/main.yml` (`1.17.0`) so the documented and effective defaults match.
+
 ### Changed
 
 - **Molecule (CI)**: run the alloy scenario on Debian 12 in addition to
   Ubuntu 22.04 (was Ubuntu-only), matching the two-distro coverage of the
   do and tailscale scenarios.
-
-
+- **Tailscale metadata**: drop EOL Ubuntu `focal`, add `noble`, and add the `EL`
+  platform (8, 9) to `galaxy_info.platforms`, matching the RedHat-family support
+  already shipped in `vars/main.yml`. (Galaxy's platform enum has no Alpine/Arch
+  entries, so those remain expressed via `vars/` only.)
+- **Role READMEs**: link the `alloy`, `do`, and `tailscale` READMEs to the
+  collection `CHANGELOG.md` so version history is discoverable from each role.
 - Raise the Python target to `3.13` (the highest version `ansible-test`
   supports): bump `python_version` in `pull-request.yml` and `merge.yml` so CI
   exercises the same interpreter the release artifact is built with, matching

--- a/roles/alloy/README.md
+++ b/roles/alloy/README.md
@@ -34,6 +34,10 @@ For detailed documentation including all variables, examples, and usage instruct
 
 MIT
 
+## Changelog
+
+See [CHANGELOG.md](../../CHANGELOG.md) for the collection version history.
+
 ## Author Information
 
 This role was created by [arillso](https://github.com/arillso).

--- a/roles/alloy/meta/argument_specs.yml
+++ b/roles/alloy/meta/argument_specs.yml
@@ -826,7 +826,7 @@ argument_specs:
             alloy_version: &alloy_version
                 type: "str"
                 required: false
-                default: "1.13.2"
+                default: "1.17.0"
                 description: "Version of the Grafana Alloy package"
 
             # Node exporter configuration options

--- a/roles/alloy/meta/argument_specs.yml
+++ b/roles/alloy/meta/argument_specs.yml
@@ -826,6 +826,7 @@ argument_specs:
             alloy_version: &alloy_version
                 type: "str"
                 required: false
+                # renovate: datasource=github-releases depName=grafana/alloy extractVersion=^v(?<version>.*)$
                 default: "1.17.0"
                 description: "Version of the Grafana Alloy package"
 

--- a/roles/alloy/molecule/default/side_effect.yml
+++ b/roles/alloy/molecule/default/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/do/README.md
+++ b/roles/do/README.md
@@ -28,6 +28,10 @@ For detailed documentation including all variables, examples, and usage instruct
 
 MIT
 
+## Changelog
+
+See [CHANGELOG.md](../../CHANGELOG.md) for the collection version history.
+
 ## Author Information
 
 This role was created by [arillso](https://github.com/arillso).

--- a/roles/do/meta/argument_specs.yml
+++ b/roles/do/meta/argument_specs.yml
@@ -19,7 +19,8 @@ argument_specs:
             do_version:
                 type: "str"
                 required: false
-                default: "3.18.8"
+                # renovate: datasource=github-releases depName=digitalocean/do-agent
+                default: "3.18.14"
                 description: "Version of the DigitalOcean Agent package"
 
             do_port:

--- a/roles/do/molecule/default/side_effect.yml
+++ b/roles/do/molecule/default/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/tailscale/README.md
+++ b/roles/tailscale/README.md
@@ -35,6 +35,10 @@ For detailed documentation including all variables, examples, and usage instruct
 
 MIT
 
+## Changelog
+
+See [CHANGELOG.md](../../CHANGELOG.md) for the collection version history.
+
 ## Author Information
 
 This role was created by [arillso](https://github.com/arillso).

--- a/roles/tailscale/meta/argument_specs.yml
+++ b/roles/tailscale/meta/argument_specs.yml
@@ -28,7 +28,8 @@ argument_specs:
             tailscale_version:
                 type: "str"
                 required: false
-                default: "1.94.2"
+                # renovate: datasource=github-releases depName=tailscale/tailscale extractVersion=^v(?<version>.*)$
+                default: "1.98.5"
                 description: "Version of the Tailscale package"
 
             tailscale_service_state:

--- a/roles/tailscale/meta/main.yml
+++ b/roles/tailscale/meta/main.yml
@@ -16,12 +16,16 @@ galaxy_info:
     platforms:
         - name: Ubuntu
           versions:
-              - focal
               - jammy
+              - noble
         - name: Debian
           versions:
               - bullseye
               - bookworm
+        - name: EL
+          versions:
+              - "8"
+              - "9"
 
     galaxy_tags:
         - networking

--- a/roles/tailscale/molecule/default/side_effect.yml
+++ b/roles/tailscale/molecule/default/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."


### PR DESCRIPTION
## Summary

- Add missing `side_effect.yml` to alloy/do/tailscale default scenarios (test_sequence referenced a step with no file → `molecule test` failed before verify)
- Align `alloy_version` default in argument_specs (`1.13.2` → `1.17.0`) with defaults/main.yml
- Tailscale meta: drop EOL `focal`, add `noble` + `EL` (8,9) platforms; link role READMEs to CHANGELOG

Resolves audited Notion tickets for the agent collection.

## Test plan

- [ ] CI green (lint + per-role molecule)
- [x] `ansible-lint roles/` → 0 failures, production profile
- [x] all 3 side_effect.yml parse + lint clean