### PR TITLE
feat(alloy,tailscale): textfile collector and tailscale fixes

### DIFF
--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -104,7 +104,10 @@ alloy_custom_exporters: []
 
 # Textfile collector scripts for node_exporter / prometheus.exporter.unix.
 # Each entry deploys a script plus a oneshot systemd .service and .timer.
-alloy_textfile_collector_directory: "/var/lib/node_exporter/textfile_collector"
+# Defaults to the same directory prometheus.exporter.unix actually scrapes
+# (alloy_node_exporter_config.textfile_directory) so scripts write where
+# Alloy reads — override that one var to move both in lockstep.
+alloy_textfile_collector_directory: "{{ alloy_node_exporter_config.textfile_directory }}"
 alloy_textfile_script_directory: "/usr/local/lib/node-textfile"
 alloy_textfile_scripts: []
 # Example:

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -102,6 +102,19 @@ alloy_prometheus_remote_write:
 # Custom exporters
 alloy_custom_exporters: []
 
+# Textfile collector scripts for node_exporter / prometheus.exporter.unix.
+# Each entry deploys a script plus a oneshot systemd .service and .timer.
+alloy_textfile_collector_directory: "/var/lib/node_exporter/textfile_collector"
+alloy_textfile_script_directory: "/usr/local/lib/node-textfile"
+alloy_textfile_scripts: []
+# Example:
+# alloy_textfile_scripts:
+#   - name: zram                                # systemd unit suffix + script basename
+#     src: node-textfile/zram.sh                # looked up via files/ search path
+#     description: "Export zram statistics"     # optional, used in unit Description
+#     interval: "30s"                           # systemd OnUnitActiveSec
+#     on_boot_sec: "15s"                        # systemd OnBootSec
+
 # Loki configuration
 alloy_enable_loki: false
 alloy_loki_file_sources: []

--- a/roles/alloy/meta/argument_specs.yml
+++ b/roles/alloy/meta/argument_specs.yml
@@ -583,6 +583,52 @@ argument_specs:
                         description: "Metric relabel configurations"
                         elements: "dict"
 
+            alloy_textfile_collector_directory: &alloy_textfile_collector_directory
+                type: "str"
+                required: false
+                default: "/var/lib/node_exporter/textfile_collector"
+                description: >-
+                    Directory the textfile collector of prometheus.exporter.unix reads
+                    .prom files from. Created unconditionally by the role.
+
+            alloy_textfile_script_directory: &alloy_textfile_script_directory
+                type: "str"
+                required: false
+                default: "/usr/local/lib/node-textfile"
+                description: "Filesystem location for textfile-collector scripts deployed by this role."
+
+            alloy_textfile_scripts: &alloy_textfile_scripts
+                type: "list"
+                required: false
+                default: []
+                description: >-
+                    Scripts deployed as oneshot systemd .service + .timer pairs that
+                    write .prom files into alloy_textfile_collector_directory.
+                elements: "dict"
+                options:
+                    name:
+                        type: "str"
+                        required: true
+                        description: "Identifier; used as systemd unit suffix and script basename."
+                    src:
+                        type: "str"
+                        required: true
+                        description: "Script source path, resolved via Ansible's files/ search path."
+                    description:
+                        type: "str"
+                        required: false
+                        description: "Human-readable description for the systemd Unit Description= field."
+                    interval:
+                        type: "str"
+                        required: false
+                        default: "60s"
+                        description: "systemd OnUnitActiveSec= value (e.g. '30s')."
+                    on_boot_sec:
+                        type: "str"
+                        required: false
+                        default: "15s"
+                        description: "systemd OnBootSec= value."
+
             alloy_enable_loki: &alloy_enable_loki
                 type: "bool"
                 required: false
@@ -1212,6 +1258,9 @@ argument_specs:
             alloy_prometheus_remote_write: *alloy_prometheus_remote_write
             alloy_prometheus_relabel_configs: *alloy_prometheus_relabel_configs
             alloy_custom_exporters: *alloy_custom_exporters
+            alloy_textfile_collector_directory: *alloy_textfile_collector_directory
+            alloy_textfile_script_directory: *alloy_textfile_script_directory
+            alloy_textfile_scripts: *alloy_textfile_scripts
             alloy_enable_loki: *alloy_enable_loki
             alloy_loki_file_sources: *alloy_loki_file_sources
             alloy_loki_journal_enabled: *alloy_loki_journal_enabled

--- a/roles/alloy/meta/argument_specs.yml
+++ b/roles/alloy/meta/argument_specs.yml
@@ -588,8 +588,11 @@ argument_specs:
                 required: false
                 default: "/var/lib/node_exporter/textfile_collector"
                 description: >-
-                    Directory the textfile collector of prometheus.exporter.unix reads
-                    .prom files from. Created unconditionally by the role.
+                    Directory the textfile collector scripts write .prom files to;
+                    created unconditionally by the role. Defaults to
+                    alloy_node_exporter_config.textfile_directory so it stays in sync
+                    with the path prometheus.exporter.unix actually scrapes. Override
+                    only if scripts must write somewhere other than what Alloy reads.
 
             alloy_textfile_script_directory: &alloy_textfile_script_directory
                 type: "str"

--- a/roles/alloy/tasks/main.yml
+++ b/roles/alloy/tasks/main.yml
@@ -19,3 +19,9 @@
   tags:
       - alloy
       - service
+
+- name: Include textfile collector script deployment
+  ansible.builtin.include_tasks: textfile.yml
+  tags:
+      - alloy
+      - textfile

--- a/roles/alloy/tasks/textfile.yml
+++ b/roles/alloy/tasks/textfile.yml
@@ -1,0 +1,97 @@
+---
+# Textfile-Script deployment for node_exporter / prometheus.exporter.unix.
+#
+# Architecture:
+# - alloy_textfile_collector_directory is created unconditionally so the Fleet-
+#   managed textfile collector never fires node_textfile_scrape_error on hosts
+#   that simply have no scripts.
+# - For each entry in alloy_textfile_scripts: script + .service (oneshot) +
+#   .timer get deployed; the timer is restarted only when its unit file
+#   actually changed, so OnBootSec=/OnUnitActiveSec= updates take effect
+#   without churning idempotence on re-runs.
+
+- name: Ensure textfile collector directory exists
+  ansible.builtin.file:
+      path: "{{ alloy_textfile_collector_directory }}"
+      state: directory
+      owner: root
+      group: root
+      mode: "0755"
+  become: true
+
+- name: Ensure textfile script directory exists
+  ansible.builtin.file:
+      path: "{{ alloy_textfile_script_directory }}"
+      state: directory
+      owner: root
+      group: root
+      mode: "0755"
+  become: true
+  when: alloy_textfile_scripts | length > 0
+
+- name: Deploy textfile collector scripts
+  ansible.builtin.copy:
+      src: "{{ item.src }}"
+      dest: "{{ alloy_textfile_script_directory }}/{{ item.name }}.sh"
+      owner: root
+      group: root
+      mode: "0755"
+  become: true
+  loop: "{{ alloy_textfile_scripts }}"
+  loop_control:
+      label: "{{ item.name }}"
+
+- name: Deploy textfile collector systemd .service units
+  ansible.builtin.template:
+      src: etc/systemd/system/node-textfile.service.j2
+      dest: "/etc/systemd/system/node-textfile-{{ item.name }}.service"
+      owner: root
+      group: root
+      mode: "0644"
+  become: true
+  loop: "{{ alloy_textfile_scripts }}"
+  loop_control:
+      label: "{{ item.name }}"
+  register: _alloy_textfile_service_units
+  notify: reload systemd
+
+- name: Deploy textfile collector systemd .timer units
+  ansible.builtin.template:
+      src: etc/systemd/system/node-textfile.timer.j2
+      dest: "/etc/systemd/system/node-textfile-{{ item.name }}.timer"
+      owner: root
+      group: root
+      mode: "0644"
+  become: true
+  loop: "{{ alloy_textfile_scripts }}"
+  loop_control:
+      label: "{{ item.name }}"
+  register: _alloy_textfile_timer_units
+  notify: reload systemd
+
+- name: Apply pending systemd daemon-reload before timer enable
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start textfile collector timers
+  ansible.builtin.systemd_service:
+      name: "node-textfile-{{ item.name }}.timer"
+      enabled: true
+      state: started
+  become: true
+  loop: "{{ alloy_textfile_scripts }}"
+  loop_control:
+      label: "{{ item.name }}"
+
+# daemon-reload alone does not reapply OnBootSec=/OnUnitActiveSec= to an
+# already-running timer — only an actual restart picks up the new schedule.
+# Restart only the timers whose .service or .timer unit file changed in this
+# run, so unchanged hosts stay at changed=0.
+- name: Restart textfile collector timers when their unit files changed
+  ansible.builtin.systemd_service:
+      name: "node-textfile-{{ item.0.item.name }}.timer"
+      state: restarted
+  become: true
+  loop: "{{ _alloy_textfile_service_units.results | zip(_alloy_textfile_timer_units.results) | list }}"
+  loop_control:
+      label: "{{ item.0.item.name }}"
+  when: item.0.changed or item.1.changed

--- a/roles/alloy/templates/etc/systemd/system/node-textfile.service.j2
+++ b/roles/alloy/templates/etc/systemd/system/node-textfile.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description={{ item.description | default('Node textfile collector: ' + item.name) }}
+After=local-fs.target
+
+[Service]
+Type=oneshot
+Environment=TEXTFILE_DIR={{ alloy_textfile_collector_directory }}
+ExecStart={{ alloy_textfile_script_directory }}/{{ item.name }}.sh
+Nice=10
+IOSchedulingClass=idle
+ProtectSystem=strict
+ReadWritePaths={{ alloy_textfile_collector_directory }}
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true

--- a/roles/alloy/templates/etc/systemd/system/node-textfile.timer.j2
+++ b/roles/alloy/templates/etc/systemd/system/node-textfile.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Schedule for {{ item.description | default('node-textfile-' + item.name) }}
+
+[Timer]
+OnBootSec={{ item.on_boot_sec | default('15s') }}
+OnUnitActiveSec={{ item.interval | default('60s') }}
+AccuracySec=1s
+Unit=node-textfile-{{ item.name }}.service
+
+[Install]
+WantedBy=timers.target

--- a/roles/tailscale/defaults/main.yml
+++ b/roles/tailscale/defaults/main.yml
@@ -15,6 +15,11 @@ tailscale_auth_key: ""
 tailscale_tags: []
 tailscale_reset_authentication: false
 
+# Censor the auth-key `tailscale up` command output. Keep true unless
+# debugging a join failure (set false for one run to surface the real
+# error, which no_log otherwise hides as "non-zero return code").
+tailscale_no_log_auth_key: true
+
 # Run the connectivity verification phase (verify.yml). Requires a
 # running, authenticated tailscaled; disable for install-only runs.
 tailscale_verify_connectivity: true

--- a/roles/tailscale/meta/argument_specs.yml
+++ b/roles/tailscale/meta/argument_specs.yml
@@ -96,6 +96,14 @@ argument_specs:
                 default: false
                 description: "Perform logout and re-authentication (WARNING: temporary disconnect)"
 
+            tailscale_no_log_auth_key:
+                type: "bool"
+                required: false
+                default: true
+                description: >-
+                    no_log toggle for the auth-key task; set false to surface
+                    a join error hidden as 'non-zero return code'.
+
             tailscale_verify_connectivity:
                 type: "bool"
                 required: false

--- a/roles/tailscale/tasks/service.yml
+++ b/roles/tailscale/tasks/service.yml
@@ -11,8 +11,13 @@
   become: true
   tags: [tailscale, service]
 
-- name: Wait for Tailscale service to be ready
+# Wait on the control socket rather than a bare `timeout:` — the latter
+# is an unconditional 30 s sleep on every run (including idempotent
+# re-runs where the socket already exists). Keying on the socket path
+# returns as soon as tailscaled is accepting CLI calls.
+- name: Wait for Tailscale CLI socket to be ready
   ansible.builtin.wait_for:
+      path: /run/tailscale/tailscaled.sock
       timeout: 30
   when: tailscale_service_state == "started"
   tags: [tailscale, service, wait]


### PR DESCRIPTION
## Summary

### alloy — textfile collector deployment (new feature)

- `tasks/textfile.yml` + `node-textfile.{service,timer}.j2` templates: deploy a script plus a oneshot systemd `.service` and `.timer` per entry in `alloy_textfile_scripts`, writing `.prom` files into the `prometheus.exporter.unix` textfile collector directory.
- Timers restart only when their unit file changed, so schedule updates apply without breaking idempotence. Collector directory is created unconditionally so script-less hosts never raise `node_textfile_scrape_error`.
- New vars `alloy_textfile_collector_directory`, `alloy_textfile_script_directory`, `alloy_textfile_scripts` in defaults and argument_specs.

### tailscale — two fixes

- `service.yml`: wait on `/run/tailscale/tailscaled.sock` instead of a bare `timeout: 30` (was an unconditional 30 s sleep on every run, incl. idempotent re-runs).
- `tailscale_no_log_auth_key`: the var was already referenced in `configure.yml` but never declared; add it to defaults and argument_specs.

## Test plan

- [ ] CI lint + per-role molecule (alloy, tailscale)
- [ ] argument_specs validation passes with the new vars