### PR TITLE
ci(security): run security scan daily on this public repo

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -5,7 +5,7 @@ run-name: |
 
 on:
     schedule:
-        - cron: "0 2 * * 1"
+        - cron: "0 2 * * *" # Daily 02:00 UTC (public repo — Actions minutes are free)
     workflow_dispatch:
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Event-focused workflows calling reusables from `arillso/.github`:
 
 - `pull-request.yml` - Lint, unit/integration tests, per-role molecule, secret scan, and Claude review on PRs
 - `merge.yml` - Same CI plus secret scan on push to `main`
-- `nightly-security.yml` - Scheduled weekly secret scan
+- `nightly-security.yml` - Scheduled daily secret scan
 - `tag.yml` - Publishes to Ansible Galaxy on tag push (e.g. `1.0.1`)
 
 ### Release Process

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ ansible.agent/
 ├── .github/workflows/
 │   ├── pull-request.yml    # Lint, tests, secret scan, Claude review on PRs
 │   ├── merge.yml           # CI + secret scan on push to main
-│   ├── nightly-security.yml # Scheduled weekly secret scan
+│   ├── nightly-security.yml # Scheduled daily secret scan
 │   └── tag.yml             # Galaxy publishing (triggered by tag)
 ├── roles/
 │   ├── alloy/             # Grafana Alloy observability agent


### PR DESCRIPTION
## Summary

Switches the scheduled security scan to a **daily** cron `0 2 * * *`.

## Why

Per the arillso/sbaerlocher repo-standard visibility rule: **public** repos get free GitHub Actions minutes → security scan runs daily; **private** repos run it weekly to save paid minutes. `ansible.agent` is public → daily. (Standard note updated 2026-06-27.)

## Test plan

- [ ] CI green