### PR TITLE
test(ci): wire multi-role molecule scenario into pull-request CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,6 +69,20 @@ jobs:
             scenarios: '["default"]'
             concurrency-suffix: molecule-tailscale
 
+    molecule-multi-role:
+        # Combined scenario deploying alloy, do and tailscale on one host
+        # (extensions/molecule/multi-role). Docker driver like the do/tailscale
+        # default scenarios.
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
+        with:
+            collection_namespace: arillso
+            collection_name: agent
+            driver: docker
+            python_version: "3.13"
+            scenarios_root: extensions/molecule
+            scenarios: '["multi-role"]'
+            concurrency-suffix: molecule-multi-role
+
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-18
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,10 +67,12 @@ Three-level testing strategy:
     - Location: `tests/unit/`
     - Run: `pytest tests/unit/`
 
-2. **Molecule Tests** - For individual roles
-    - Location: `roles/*/molecule/default/`
-    - Run: `molecule test -s default`
-    - CI: one `molecule-<role>` job per role in `pull-request.yml`
+2. **Molecule Tests** - Per-role and combined
+    - Per-role location: `roles/*/molecule/default/`
+    - Combined location: `extensions/molecule/multi-role/` (deploys alloy, do
+      and tailscale together on one host)
+    - Run: `molecule test -s default` (per role) / `molecule test -s multi-role`
+    - CI: one `molecule-<role>` job per role plus `molecule-multi-role` in `pull-request.yml`
 
 3. **Integration Tests** (ansible-test) - For role integration
     - Location: `tests/integration/targets/`

--- a/extensions/molecule/multi-role/converge.yml
+++ b/extensions/molecule/multi-role/converge.yml
@@ -6,9 +6,20 @@
   hosts: all
   become: true
 
-  roles:
+  # The roles are loaded via `ansible.builtin.include_role` rather than a static
+  # `roles:` block. Under `scenarios_root: extensions/molecule` molecule runs
+  # `ansible-playbook --syntax-check` from the `extensions/` project directory,
+  # and Ansible's static role pre-parse does not add the collection root to the
+  # roles search path, so `arillso.agent.<role>` is not found at syntax time
+  # (it lists only the scenario-local `roles/` dir and the galaxy defaults).
+  # `include_role` defers FQCN resolution to converge runtime, where molecule's
+  # prerun has the collection on the finder path — exactly how the per-role
+  # default scenarios resolve their own `arillso.agent.<role>` FQCN.
+  tasks:
       # 1. Grafana Alloy
-      - role: arillso.agent.alloy
+      - name: Deploy Grafana Alloy
+        ansible.builtin.include_role:
+            name: arillso.agent.alloy
         vars:
             # Enable Prometheus scraping/remote-write (uses the role's default
             # localhost remote_write target).
@@ -25,7 +36,9 @@
             alloy_health_check_enabled: false
 
       # 2. DigitalOcean Agent
-      - role: arillso.agent.do
+      - name: Deploy DigitalOcean Agent
+        ansible.builtin.include_role:
+            name: arillso.agent.do
         vars:
             # Disable health checks for testing (no actual DO metadata service).
             do_health_check_enabled: false
@@ -37,7 +50,9 @@
                 - testing
 
       # 3. Tailscale
-      - role: arillso.agent.tailscale
+      - name: Deploy Tailscale
+        ansible.builtin.include_role:
+            name: arillso.agent.tailscale
         vars:
             # Auth key from the environment, never hardcoded. When unset the
             # lookup returns "" and the role skips `tailscale up` on its own

--- a/extensions/molecule/multi-role/molecule.yml
+++ b/extensions/molecule/multi-role/molecule.yml
@@ -48,10 +48,14 @@ provisioner:
         # (extensions, agent, arillso, ansible_collections) is the directory
         # that contains ansible_collections/, which is what
         # ANSIBLE_COLLECTIONS_PATH must point at. The path is relative to the
-        # process cwd (extensions/). NOTE: keep this file free of literal
-        # dollar signs in comments — molecule runs the YAML through string
-        # placeholder substitution and a bare "dollar-paren" breaks parsing.
-        ANSIBLE_COLLECTIONS_PATH: "../../../.."
+        # process cwd (extensions/). The default ~/.ansible/collections is kept
+        # second in the colon-separated list so galaxy-installed deps
+        # (community.docker, used by molecule's own create/destroy playbooks,
+        # and the runtime collection deps) are still found. NOTE: keep this
+        # file free of literal dollar signs in comments — molecule runs the
+        # YAML through string placeholder substitution and a bare
+        # "dollar-paren" breaks parsing.
+        ANSIBLE_COLLECTIONS_PATH: "../../../..:~/.ansible/collections"
     config_options:
         defaults:
             interpreter_python: auto_silent

--- a/extensions/molecule/multi-role/molecule.yml
+++ b/extensions/molecule/multi-role/molecule.yml
@@ -38,6 +38,18 @@ platforms:
 
 provisioner:
     name: ansible
+    env:
+        # This scenario lives under extensions/molecule, not roles/<role>/molecule,
+        # so Ansible's cwd-based collection autodetection does not reach the
+        # collection root and `arillso.agent.<role>` is not found at runtime.
+        # The reusable CI runs molecule from `extensions/` (it does
+        # `cd "$(dirname extensions/molecule)"`), i.e. inside
+        # ansible_collections/arillso/agent/extensions. Four levels up
+        # (extensions -> agent -> arillso -> ansible_collections) is the
+        # directory that contains `ansible_collections/`, which is what
+        # ANSIBLE_COLLECTIONS_PATH must point at. The path is relative to the
+        # process cwd (extensions/).
+        ANSIBLE_COLLECTIONS_PATH: "../../../.."
     config_options:
         defaults:
             interpreter_python: auto_silent

--- a/extensions/molecule/multi-role/molecule.yml
+++ b/extensions/molecule/multi-role/molecule.yml
@@ -41,14 +41,16 @@ provisioner:
     env:
         # This scenario lives under extensions/molecule, not roles/<role>/molecule,
         # so Ansible's cwd-based collection autodetection does not reach the
-        # collection root and `arillso.agent.<role>` is not found at runtime.
-        # The reusable CI runs molecule from `extensions/` (it does
-        # `cd "$(dirname extensions/molecule)"`), i.e. inside
+        # collection root and arillso.agent.<role> is not found at runtime.
+        # The reusable CI runs molecule from the extensions/ directory (it cds
+        # into the parent of scenarios_root), i.e. inside
         # ansible_collections/arillso/agent/extensions. Four levels up
-        # (extensions -> agent -> arillso -> ansible_collections) is the
-        # directory that contains `ansible_collections/`, which is what
+        # (extensions, agent, arillso, ansible_collections) is the directory
+        # that contains ansible_collections/, which is what
         # ANSIBLE_COLLECTIONS_PATH must point at. The path is relative to the
-        # process cwd (extensions/).
+        # process cwd (extensions/). NOTE: keep this file free of literal
+        # dollar signs in comments — molecule runs the YAML through string
+        # placeholder substitution and a bare "dollar-paren" breaks parsing.
         ANSIBLE_COLLECTIONS_PATH: "../../../.."
     config_options:
         defaults:

--- a/extensions/molecule/multi-role/molecule.yml
+++ b/extensions/molecule/multi-role/molecule.yml
@@ -10,9 +10,12 @@
 # /dev/net/tun and a valid auth key). A TAILSCALE_AUTH_KEY can still be passed
 # via the environment in converge.yml when one is available.
 #
-# The roles are resolved via the collection layout: molecule runs from the
-# collection root, so arillso.agent.<role> is found automatically. No explicit
-# roles_path is required.
+# The roles are resolved via the collection layout. Because this scenario lives
+# under extensions/molecule (not roles/<role>/molecule), the syntax step's
+# static role pre-parse does not see the collection root, so converge.yml loads
+# arillso.agent.<role> with `ansible.builtin.include_role` (runtime FQCN
+# resolution) instead of a static `roles:` block. No explicit roles_path is
+# required.
 
 dependency:
     name: galaxy

--- a/extensions/molecule/multi-role/molecule.yml
+++ b/extensions/molecule/multi-role/molecule.yml
@@ -41,21 +41,21 @@ provisioner:
     env:
         # This scenario lives under extensions/molecule, not roles/<role>/molecule,
         # so Ansible's cwd-based collection autodetection does not reach the
-        # collection root and arillso.agent.<role> is not found at runtime.
-        # The reusable CI runs molecule from the extensions/ directory (it cds
-        # into the parent of scenarios_root), i.e. inside
-        # ansible_collections/arillso/agent/extensions. Four levels up
-        # (extensions, agent, arillso, ansible_collections) is the directory
-        # that contains ansible_collections/, which is what
-        # ANSIBLE_COLLECTIONS_PATH must point at. The path is relative to the
-        # process cwd (extensions/). The default ~/.ansible/collections is kept
-        # second in the colon-separated list so galaxy-installed deps
-        # (community.docker, used by molecule's own create/destroy playbooks,
-        # and the runtime collection deps) are still found. NOTE: keep this
-        # file free of literal dollar signs in comments — molecule runs the
-        # YAML through string placeholder substitution and a bare
-        # "dollar-paren" breaks parsing.
-        ANSIBLE_COLLECTIONS_PATH: "../../../..:~/.ansible/collections"
+        # collection root and arillso.agent.<role> is not found at converge
+        # runtime. molecule expands MOLECULE_PROJECT_DIRECTORY to the absolute
+        # collection root (.../ansible_collections/arillso/agent); three levels
+        # up (agent, arillso, ansible_collections) is the directory that
+        # contains ansible_collections/, which is what ANSIBLE_COLLECTIONS_PATH
+        # must point at. An absolute base is required because molecule changes
+        # cwd between phases, so a relative path would resolve differently per
+        # phase. The default galaxy path is kept second in the colon-separated
+        # list so installed deps (community.docker, used by molecule's own
+        # docker create/destroy playbooks) still resolve. NOTE: only
+        # MOLECULE_* placeholders are expanded here; keep any other literal
+        # dollar signs out of this file (comments included) — molecule runs the
+        # YAML through string placeholder substitution and an unknown
+        # placeholder breaks parsing.
+        ANSIBLE_COLLECTIONS_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../../..:~/.ansible/collections"
     config_options:
         defaults:
             interpreter_python: auto_silent


### PR DESCRIPTION
## Summary

Adds a `molecule-multi-role` job to `pull-request.yml` so the combined scenario `extensions/molecule/multi-role/` (alloy + do + tailscale on one host, added in #98) runs automatically on every PR. Docker driver, matching the `do`/`tailscale` per-role jobs. Documents the combined scenario in AGENTS.md.

## Why

The multi-role scenario existed but was never wired into CI, so the cross-role interaction was only testable manually. Closes the Notion intake card "Integrationstest fuer Multi-Rollen-Playbook".

## Test plan

- [ ] CI green, `molecule-multi-role` job converges + verifies all three roles