### PR TITLE
fix(alloy)!: censor Grafana Cloud tokens and declare their variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Alloy (breaking)**: the six unprefixed Grafana Cloud variables the role read
+  are replaced by role-prefixed names. They were never declared in
+  `defaults/main.yml` or `meta/argument_specs.yml` and worked only through
+  `| default('')` guards in the template, so no documented interface changes.
+  Rename them in your inventory:
+
+    | Old                              | New                                    |
+    | -------------------------------- | -------------------------------------- |
+    | `grafana_cloud_prometheus_user`  | `alloy_grafana_cloud_prometheus_user`  |
+    | `grafana_cloud_prometheus_token` | `alloy_grafana_cloud_prometheus_token` |
+    | `grafana_cloud_loki_user`        | `alloy_grafana_cloud_loki_user`        |
+    | `grafana_cloud_loki_token`       | `alloy_grafana_cloud_loki_token`       |
+    | `grafana_cloud_fleet_user`       | `alloy_grafana_cloud_fleet_user`       |
+    | `grafana_cloud_fleet_token`      | `alloy_grafana_cloud_fleet_token`      |
+
+    The `GRAFANA_CLOUD_*` keys inside the environment file are unchanged — Alloy
+    itself reads those. All seven variables are now declared in
+    `defaults/main.yml` and `meta/argument_specs.yml`, the three tokens with
+    `no_log: true`.
+
 ### Fixed
 
+- **Alloy**: add `no_log` to the `Create environment file` task, which renders
+  the Grafana Cloud tokens. Without it the credentials appeared in the Ansible
+  output at raised verbosity. The new `alloy_no_log_env_file` toggle (default
+  `true`) allows disabling it for a single debugging run, mirroring
+  `tailscale_no_log_auth_key`.
+- **Alloy**: tighten `/etc/default/alloy` from mode `0640` to `0600`. The file
+  holds the Grafana Cloud credentials and is read by systemd as root, so group
+  read access was never needed.
 - **Molecule (all roles)**: add the missing `side_effect.yml` play to the
   `alloy`, `do`, and `tailscale` default scenarios. Their `test_sequence`
   referenced a `side_effect` step with no matching file, so `molecule test`

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -45,6 +45,19 @@ alloy_config_file: "/etc/alloy/config.alloy"
 # Environment file path
 alloy_env_file: "/etc/default/alloy"
 
+# Grafana Cloud credentials, rendered into the environment file
+alloy_grafana_cloud_prometheus_user: ""
+alloy_grafana_cloud_prometheus_token: ""
+alloy_grafana_cloud_loki_user: ""
+alloy_grafana_cloud_loki_token: ""
+alloy_grafana_cloud_fleet_user: ""
+alloy_grafana_cloud_fleet_token: ""
+
+# Censor the environment file task, which renders the Grafana Cloud
+# credentials. Keep true unless debugging a template failure (set false
+# for one run to surface the real error, which no_log otherwise hides).
+alloy_no_log_env_file: true
+
 # User and group configuration
 alloy_user: "alloy"
 alloy_group: "alloy"
@@ -217,7 +230,7 @@ alloy_remotecfg: {}
 #     environment: "production"
 #     node_type: "gateway"
 #   basic_auth:
-#     username: "{{ grafana_cloud_fleet_user }}"
+#     username: "{{ alloy_grafana_cloud_fleet_user }}"
 #     password: "env:GRAFANA_CLOUD_FLEET_API_KEY"
 #   # Alternative authentication methods:
 #   # bearer_token: "env:GRAFANA_FLEET_TOKEN"

--- a/roles/alloy/meta/argument_specs.yml
+++ b/roles/alloy/meta/argument_specs.yml
@@ -583,7 +583,8 @@ argument_specs:
                         description: "Metric relabel configurations"
                         elements: "dict"
 
-            alloy_textfile_collector_directory: &alloy_textfile_collector_directory
+            alloy_textfile_collector_directory:
+                &alloy_textfile_collector_directory
                 type: "str"
                 required: false
                 default: "/var/lib/node_exporter/textfile_collector"
@@ -1192,6 +1193,67 @@ argument_specs:
                 default: "/etc/systemd/system/alloy.service"
                 description: "Path to the systemd service file for Grafana Alloy"
 
+            alloy_grafana_cloud_prometheus_user:
+                &alloy_grafana_cloud_prometheus_user
+                type: "str"
+                required: false
+                default: ""
+                description: >-
+                    Grafana Cloud Prometheus username (instance ID), written to
+                    the environment file as GRAFANA_CLOUD_PROMETHEUS_USER.
+
+            alloy_grafana_cloud_prometheus_token:
+                &alloy_grafana_cloud_prometheus_token
+                type: "str"
+                required: false
+                default: ""
+                no_log: true
+                description: >-
+                    Grafana Cloud Prometheus API token. Supply through Ansible
+                    Vault or the CI environment, never in plain group_vars.
+
+            alloy_grafana_cloud_loki_user: &alloy_grafana_cloud_loki_user
+                type: "str"
+                required: false
+                default: ""
+                description: >-
+                    Grafana Cloud Loki username (instance ID), written to the
+                    environment file as GRAFANA_CLOUD_LOKI_USER.
+
+            alloy_grafana_cloud_loki_token: &alloy_grafana_cloud_loki_token
+                type: "str"
+                required: false
+                default: ""
+                no_log: true
+                description: >-
+                    Grafana Cloud Loki API token. Supply through Ansible Vault
+                    or the CI environment, never in plain group_vars.
+
+            alloy_grafana_cloud_fleet_user: &alloy_grafana_cloud_fleet_user
+                type: "str"
+                required: false
+                default: ""
+                description: >-
+                    Grafana Cloud Fleet Management username, rendered only when
+                    alloy_enable_remotecfg is true.
+
+            alloy_grafana_cloud_fleet_token: &alloy_grafana_cloud_fleet_token
+                type: "str"
+                required: false
+                default: ""
+                no_log: true
+                description: >-
+                    Grafana Cloud Fleet Management API token, rendered only when
+                    alloy_enable_remotecfg is true. Supply through Ansible Vault.
+
+            alloy_no_log_env_file: &alloy_no_log_env_file
+                type: "bool"
+                required: false
+                default: true
+                description: >-
+                    no_log toggle for the environment file task; set false to
+                    surface a template error the censored output otherwise hides.
+
     install:
         short_description: "Install Grafana Alloy package and dependencies"
         description: |
@@ -1286,6 +1348,13 @@ argument_specs:
             alloy_otel_exporters: *alloy_otel_exporters
             alloy_enable_remotecfg: *alloy_enable_remotecfg
             alloy_remotecfg: *alloy_remotecfg
+            alloy_grafana_cloud_prometheus_user: *alloy_grafana_cloud_prometheus_user
+            alloy_grafana_cloud_prometheus_token: *alloy_grafana_cloud_prometheus_token
+            alloy_grafana_cloud_loki_user: *alloy_grafana_cloud_loki_user
+            alloy_grafana_cloud_loki_token: *alloy_grafana_cloud_loki_token
+            alloy_grafana_cloud_fleet_user: *alloy_grafana_cloud_fleet_user
+            alloy_grafana_cloud_fleet_token: *alloy_grafana_cloud_fleet_token
+            alloy_no_log_env_file: *alloy_no_log_env_file
 
     service:
         short_description: "Manage Grafana Alloy systemd service"

--- a/roles/alloy/tasks/configure.yml
+++ b/roles/alloy/tasks/configure.yml
@@ -39,9 +39,10 @@
       dest: "{{ alloy_env_file }}"
       owner: root
       group: root
-      mode: "0640"
+      mode: "0600"
   become: true
   notify: restart alloy
+  no_log: "{{ alloy_no_log_env_file | default(true) }}"
 
 - name: Ensure log directory exists with proper permissions
   ansible.builtin.file:

--- a/roles/alloy/templates/etc/default/alloy.j2
+++ b/roles/alloy/templates/etc/default/alloy.j2
@@ -22,23 +22,23 @@ ALLOY_CLUSTER_ADVERTISE_ADDRESS={{ alloy_cluster_advertise_address }}
 
 # Grafana Cloud API credentials - loaded from Ansible variables
 # These must be provided via ansible-vault or CI/CD environment variables
-{% if grafana_cloud_prometheus_token | default('') | length > 0 and grafana_cloud_prometheus_token != 'your-grafana-cloud-prometheus-token' %}
-GRAFANA_CLOUD_PROMETHEUS_TOKEN={{ grafana_cloud_prometheus_token }}
-GRAFANA_CLOUD_PROMETHEUS_USER={{ grafana_cloud_prometheus_user | default('') }}
+{% if alloy_grafana_cloud_prometheus_token | default('') | length > 0 and alloy_grafana_cloud_prometheus_token != 'your-grafana-cloud-prometheus-token' %}
+GRAFANA_CLOUD_PROMETHEUS_TOKEN={{ alloy_grafana_cloud_prometheus_token }}
+GRAFANA_CLOUD_PROMETHEUS_USER={{ alloy_grafana_cloud_prometheus_user | default('') }}
 {% endif %}
 
-{% if grafana_cloud_loki_token | default('') | length > 0 and grafana_cloud_loki_token != 'your-grafana-cloud-loki-token' %}
-GRAFANA_CLOUD_LOKI_TOKEN={{ grafana_cloud_loki_token }}
-GRAFANA_CLOUD_LOKI_USER={{ grafana_cloud_loki_user | default('') }}
+{% if alloy_grafana_cloud_loki_token | default('') | length > 0 and alloy_grafana_cloud_loki_token != 'your-grafana-cloud-loki-token' %}
+GRAFANA_CLOUD_LOKI_TOKEN={{ alloy_grafana_cloud_loki_token }}
+GRAFANA_CLOUD_LOKI_USER={{ alloy_grafana_cloud_loki_user | default('') }}
 {% endif %}
 
 # Grafana Remote Configuration credentials
 {% if alloy_enable_remotecfg | default(false) %}
-{% if grafana_cloud_fleet_user | default('') | length > 0 %}
-GRAFANA_CLOUD_FLEET_USER={{ grafana_cloud_fleet_user }}
+{% if alloy_grafana_cloud_fleet_user | default('') | length > 0 %}
+GRAFANA_CLOUD_FLEET_USER={{ alloy_grafana_cloud_fleet_user }}
 {% endif %}
-{% if grafana_cloud_fleet_token | default('') | length > 0 and grafana_cloud_fleet_token != 'your-grafana-cloud-fleet-token' %}
-GRAFANA_CLOUD_FLEET_TOKEN={{ grafana_cloud_fleet_token }}
+{% if alloy_grafana_cloud_fleet_token | default('') | length > 0 and alloy_grafana_cloud_fleet_token != 'your-grafana-cloud-fleet-token' %}
+GRAFANA_CLOUD_FLEET_TOKEN={{ alloy_grafana_cloud_fleet_token }}
 {% endif %}
 {% endif %}
 

--- a/tests/unit/test_alloy_env_template.py
+++ b/tests/unit/test_alloy_env_template.py
@@ -1,0 +1,134 @@
+"""Render the alloy environment-file template and pin the variable naming contract.
+
+The template is rendered directly through Jinja2, so these tests need neither an
+Ansible controller nor a target host.
+"""
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+TEMPLATE_DIR = (
+    Path(__file__).resolve().parents[2] / "roles" / "alloy" / "templates"
+)
+TEMPLATE_NAME = "etc/default/alloy.j2"
+
+# Values the template must render regardless of the credential variables.
+BASE_VARS = {
+    "alloy_log_level": "info",
+    "alloy_log_format": "logfmt",
+    "alloy_server_http_listen_address": "127.0.0.1",
+    "alloy_port": 12345,
+    "alloy_server_grpc_listen_address": "127.0.0.1",
+    "alloy_grpc_port": 12346,
+    "alloy_storage_path": "/var/lib/alloy",
+    "alloy_clustering_enabled": False,
+}
+
+# Rendered-value markers. Deliberately not credential-shaped: secret scanners
+# flag short "<word>-token" literals as candidate API keys.
+CREDENTIAL_VARS = {
+    "alloy_grafana_cloud_prometheus_user": "rendered-prometheus-username",
+    "alloy_grafana_cloud_prometheus_token": "rendered-prometheus-credential",
+    "alloy_grafana_cloud_loki_user": "rendered-loki-username",
+    "alloy_grafana_cloud_loki_token": "rendered-loki-credential",
+    "alloy_grafana_cloud_fleet_user": "rendered-fleet-username",
+    "alloy_grafana_cloud_fleet_token": "rendered-fleet-credential",
+}
+
+# The pre-migration names, which the template must no longer read.
+LEGACY_NAMES = [name.removeprefix("alloy_") for name in CREDENTIAL_VARS]
+
+
+def render(**overrides):
+    """Render the template with StrictUndefined so unset reads raise."""
+    env = Environment(
+        loader=FileSystemLoader(TEMPLATE_DIR),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    context = {**BASE_VARS, **overrides}
+    return env.get_template(TEMPLATE_NAME).render(**context)
+
+
+def test_prefixed_credentials_render():
+    """The prefixed variables reach the rendered environment file."""
+    output = render(**CREDENTIAL_VARS, alloy_enable_remotecfg=True)
+
+    assert "GRAFANA_CLOUD_PROMETHEUS_TOKEN=rendered-prometheus-credential" in output
+    assert "GRAFANA_CLOUD_PROMETHEUS_USER=rendered-prometheus-username" in output
+    assert "GRAFANA_CLOUD_LOKI_TOKEN=rendered-loki-credential" in output
+    assert "GRAFANA_CLOUD_LOKI_USER=rendered-loki-username" in output
+
+
+def test_template_reads_no_unprefixed_names():
+    """No unprefixed grafana_cloud_* name is left in the template source."""
+    source = (TEMPLATE_DIR / TEMPLATE_NAME).read_text(encoding="utf-8")
+
+    for legacy in LEGACY_NAMES:
+        assert f"{{{{ {legacy}" not in source, f"template still reads {legacy}"
+        assert f"if {legacy}" not in source, f"template still guards on {legacy}"
+
+
+def test_legacy_names_are_ignored():
+    """Values supplied under the old names do not reach the output."""
+    legacy_values = {name: f"legacy-{name}" for name in LEGACY_NAMES}
+    output = render(**legacy_values, alloy_enable_remotecfg=True)
+
+    assert "legacy-" not in output
+
+
+def test_credentials_omitted_when_unset():
+    """Without credentials the token keys are absent, not rendered empty."""
+    output = render(alloy_enable_remotecfg=True)
+
+    assert "GRAFANA_CLOUD_PROMETHEUS_TOKEN" not in output
+    assert "GRAFANA_CLOUD_LOKI_TOKEN" not in output
+    assert "GRAFANA_CLOUD_FLEET_TOKEN" not in output
+
+
+@pytest.mark.parametrize(
+    ("variable", "placeholder", "key"),
+    [
+        (
+            "alloy_grafana_cloud_prometheus_token",
+            "your-grafana-cloud-prometheus-token",
+            "GRAFANA_CLOUD_PROMETHEUS_TOKEN",
+        ),
+        (
+            "alloy_grafana_cloud_loki_token",
+            "your-grafana-cloud-loki-token",
+            "GRAFANA_CLOUD_LOKI_TOKEN",
+        ),
+        (
+            "alloy_grafana_cloud_fleet_token",
+            "your-grafana-cloud-fleet-token",
+            "GRAFANA_CLOUD_FLEET_TOKEN",
+        ),
+    ],
+)
+def test_placeholder_values_are_suppressed(variable, placeholder, key):
+    """The shipped placeholder values never reach the environment file."""
+    output = render(**{variable: placeholder}, alloy_enable_remotecfg=True)
+
+    assert key not in output
+
+
+def test_fleet_credentials_require_remotecfg():
+    """Fleet credentials render only when remotecfg is enabled."""
+    disabled = render(**CREDENTIAL_VARS, alloy_enable_remotecfg=False)
+    enabled = render(**CREDENTIAL_VARS, alloy_enable_remotecfg=True)
+
+    assert "GRAFANA_CLOUD_FLEET_TOKEN" not in disabled
+    assert "GRAFANA_CLOUD_FLEET_TOKEN=rendered-fleet-credential" in enabled
+    assert "GRAFANA_CLOUD_FLEET_USER=rendered-fleet-username" in enabled
+
+
+def test_base_settings_render_without_credentials():
+    """The non-credential part of the file is independent of the migration."""
+    output = render(alloy_enable_remotecfg=False)
+
+    assert "ALLOY_LOG_LEVEL=info" in output
+    assert "ALLOY_SERVER_HTTP_LISTEN_ADDRESS=127.0.0.1:12345" in output
+    assert "ALLOY_STORAGE_PATH=/var/lib/alloy" in output


### PR DESCRIPTION
## Summary

- The `Create environment file` task rendered six Grafana Cloud credentials without `no_log`, so the tokens appeared in the Ansible output at raised verbosity. Added `no_log`, switchable via the new `alloy_no_log_env_file` (default `true`), mirroring `tailscale_no_log_auth_key`.
- Tightened `/etc/default/alloy` from mode `0640` to `0600`; the file holds those credentials and systemd reads it as root, so group read was never needed.
- Renamed the six `grafana_cloud_*` variables to `alloy_grafana_cloud_*` and declared all seven keys in `defaults/main.yml` and `meta/argument_specs.yml` (the three tokens with `no_log: true`). They were previously undeclared and unprefixed, working only through `| default('')` guards. Breaking change — see the rename table in the changelog.

## Test plan

- [x] `pytest tests/unit/` — 9 passed. New `tests/unit/test_alloy_env_template.py` renders the template through Jinja2 and pins the naming contract: prefixed names render, old names are ignored, placeholder values stay suppressed, fleet credentials require `alloy_enable_remotecfg`.
- [x] `configure.yml` asserted: 5 tasks unchanged, `no_log` only on the environment file task, mode `0600`.
- [x] Repo-wide grep for unprefixed `grafana_cloud_` is clean; the `GRAFANA_CLOUD_*` environment keys Alloy itself reads are untouched.
- [x] `gitleaks` clean, `yamllint` clean, `prettier --check` clean.
- [ ] CI green (`ansible-lint` and `molecule` run there; both are absent on the build host).