### PR TITLE
fix(do): stop exposing the DigitalOcean API token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failed before reaching `verify`.
 - **Alloy argument_specs**: align the `alloy_version` default (`1.13.2`) with
   `defaults/main.yml` (`1.17.0`) so the documented and effective defaults match.
+- **DO role token exposure**: the rendered agent config carried
+  `do_api_token` while being written world-readable (`0644`) and keeping
+  backup copies, and neither template task set `no_log`. The config is now
+  `0600`, backups are gone, both token-rendering tasks honour the new
+  `do_no_log_api_token` toggle (default `true`), and `do_api_token` carries
+  `no_log: true` in the argument spec again.
+  This also corrects the note under 1.0.1 claiming `no_log` is not permitted
+  in Ansible's `argument_specs` schema. It is: `ansible-lint` declares
+  `no_log` as a boolean role-arg-spec option, argument-spec validation passes
+  with it, and `ansible-galaxy collection build` succeeds.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Removed `no_log` from do role (do_api_token field)
     - Removed `no_log` from tailscale role (tailscale_auth_key field)
     - Note: The `no_log` field is not permitted in Ansible's argument_specs schema. Sensitive values are still protected via `no_log` in task definitions.
+    - Superseded (Unreleased): that note is no longer accurate. `no_log` is a valid role-arg-spec option, and it has been restored for `do_api_token`.
 
 ## [1.0.0] - 2026-01-17
 

--- a/roles/do/defaults/main.yml
+++ b/roles/do/defaults/main.yml
@@ -24,6 +24,11 @@ do_enable_insights: true
 do_api_token: ""
 do_droplet_id: ""
 
+# Censor the token-rendering template tasks. Keep true unless debugging a
+# template failure (set false for one run to surface the real error, which
+# no_log otherwise hides as "non-zero return code").
+do_no_log_api_token: true
+
 # Prometheus integration
 do_prometheus_enabled: false
 do_prometheus_port: 9091

--- a/roles/do/meta/argument_specs.yml
+++ b/roles/do/meta/argument_specs.yml
@@ -79,6 +79,14 @@ argument_specs:
                 default: ""
                 description: "ID of the DigitalOcean Droplet"
 
+            do_no_log_api_token:
+                type: "bool"
+                required: false
+                default: true
+                description: >-
+                    no_log toggle for the token-rendering tasks; set false to
+                    surface a template error hidden as 'non-zero return code'.
+
             do_enable_metrics:
                 type: "bool"
                 required: false

--- a/roles/do/meta/argument_specs.yml
+++ b/roles/do/meta/argument_specs.yml
@@ -71,6 +71,7 @@ argument_specs:
                 type: "str"
                 required: false
                 default: ""
+                no_log: true
                 description: "DigitalOcean API token for authentication"
 
             do_droplet_id:

--- a/roles/do/molecule/default/verify.yml
+++ b/roles/do/molecule/default/verify.yml
@@ -54,8 +54,9 @@
             that:
                 - do_config_file.stat.exists
                 - do_config_file.stat.isreg
-            fail_msg: "DO Agent config file does not exist"
-            success_msg: "DO Agent config file exists"
+                - do_config_file.stat.mode == '0600'
+            fail_msg: "DO Agent config file missing or not mode 0600"
+            success_msg: "DO Agent config file exists with mode 0600"
         when: do_custom_config_enabled | default(false)
 
       - name: Verify required directories exist

--- a/roles/do/tasks/configure.yml
+++ b/roles/do/tasks/configure.yml
@@ -19,6 +19,7 @@
       mode: "0600"
   become: true
   notify: restart do agent
+  no_log: "{{ do_no_log_api_token | default(true) }}"
   when: do_custom_config_enabled | default(false)
 
 - name: Create environment file for custom settings
@@ -30,4 +31,5 @@
       mode: "0600"
   become: true
   notify: restart do agent
+  no_log: "{{ do_no_log_api_token | default(true) }}"
   when: do_api_token != "" or do_custom_config_enabled | default(false)

--- a/roles/do/tasks/configure.yml
+++ b/roles/do/tasks/configure.yml
@@ -16,8 +16,7 @@
       dest: /etc/do-agent/do-agent.yaml
       owner: root
       group: root
-      mode: "0644"
-      backup: true
+      mode: "0600"
   become: true
   notify: restart do agent
   when: do_custom_config_enabled | default(false)


### PR DESCRIPTION
## Summary

- The rendered `/etc/do-agent/do-agent.yaml` embeds `do_api_token` but was written world-readable (`0644`) with `backup: true`, so every local user could read the token and each change left another plaintext copy behind. The file is now `0600` and backups are gone.
- Neither template task set `no_log`, so a verbose run printed the token. Both token-rendering tasks now honour a new `do_no_log_api_token` toggle (default `true`), following the existing `tailscale_no_log_auth_key` pattern so a template failure can still be debugged for one run.
- `do_api_token` carries `no_log: true` in the argument spec again. The 1.0.1 CHANGELOG note claiming the schema forbids it no longer holds, and that entry is corrected so it stops misleading future audits.

Scope is limited to `roles/do/`. The `alloy` role has the same class of exposure and is tracked separately.

## Test plan

- [x] `ansible-lint` clean across the collection (`production` profile, 0 failures)
- [x] `yamllint .` clean
- [x] `ansible-galaxy collection build --force` succeeds with `no_log` in the argument spec — the step that historically broke Galaxy publication
- [x] Argument-spec validation passes (`Validating arguments against arg spec 'main'` → `ok`)
- [x] Role run confirms the config renders as `0600` and both tasks report `censored due to no_log`
- [x] `gitleaks` clean on the full diff against `main`
- [ ] CI green, including the `molecule-do` scenario with the new mode assertion in `verify.yml`