### PR TITLE
refactor(roles)!: rename boolean flags to the *_enabled suffix form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING — boolean variable naming (`alloy`, `do`)**: 13 boolean variables
+  moved from the `*_enable_*` prefix form to the `*_enabled` suffix form. The
+  old names are gone; there is no deprecation alias, so playbooks setting them
+  silently lose the setting and must be updated. This also fixes the `alloy`
+  README Quick Start, which already documented the `*_enabled` names — none of
+  which existed, so copying it produced an Alloy with nothing enabled.
+
+    | Role    | Old                                   | New                                    |
+    | ------- | ------------------------------------- | -------------------------------------- |
+    | `alloy` | `alloy_enable_web_server`             | `alloy_web_server_enabled`             |
+    | `alloy` | `alloy_enable_grpc_server`            | `alloy_grpc_server_enabled`            |
+    | `alloy` | `alloy_server_http_enable_pprof`      | `alloy_server_http_pprof_enabled`      |
+    | `alloy` | `alloy_enable_prometheus`             | `alloy_prometheus_enabled`             |
+    | `alloy` | `alloy_enable_loki`                   | `alloy_loki_enabled`                   |
+    | `alloy` | `alloy_enable_otel`                   | `alloy_otel_enabled`                   |
+    | `alloy` | `alloy_enable_otel_processors`        | `alloy_otel_processors_enabled`        |
+    | `alloy` | `alloy_enable_advanced_node_exporter` | `alloy_advanced_node_exporter_enabled` |
+    | `alloy` | `alloy_enable_journal_monitoring`     | `alloy_journal_monitoring_enabled`     |
+    | `alloy` | `alloy_enable_remotecfg`              | `alloy_remotecfg_enabled`              |
+    | `do`    | `do_enable_metrics`                   | `do_metrics_enabled`                   |
+    | `do`    | `do_enable_logs`                      | `do_logs_enabled`                      |
+    | `do`    | `do_enable_insights`                  | `do_insights_enabled`                  |
+
+    The `enable_start_time_metrics`, `enable_task_metrics` and
+    `enable_restarts_metrics` keys inside `alloy_node_exporter_config.systemd`
+    are upstream Alloy configuration and are unchanged. The `tailscale` role
+    already used the suffix form and is untouched.
+
 - **Renovate**: the custom regex manager now also scans
   `roles/*/meta/argument_specs.yml`, and the `*_version` defaults in the
   `alloy`, `do`, and `tailscale` specs carry `# renovate:` comments, so future

--- a/extensions/molecule/multi-role/converge.yml
+++ b/extensions/molecule/multi-role/converge.yml
@@ -23,14 +23,14 @@
         vars:
             # Enable Prometheus scraping/remote-write (uses the role's default
             # localhost remote_write target).
-            alloy_enable_prometheus: true
+            alloy_prometheus_enabled: true
 
             # Enable the advanced node exporter integration.
-            alloy_enable_advanced_node_exporter: true
+            alloy_advanced_node_exporter_enabled: true
 
             # Enable Loki log collection (uses the role's default localhost
             # client endpoint).
-            alloy_enable_loki: true
+            alloy_loki_enabled: true
 
             # Disable health check for testing (no actual Prometheus endpoint).
             alloy_health_check_enabled: false

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: arillso
 name: agent
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.0
+version: 2.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/alloy/README.md
+++ b/roles/alloy/README.md
@@ -26,7 +26,7 @@ For detailed documentation including all variables, examples, and usage instruct
       - role: arillso.agent.alloy
         vars:
             alloy_prometheus_enabled: true
-            alloy_node_exporter_enabled: true
+            alloy_advanced_node_exporter_enabled: true
             alloy_loki_enabled: true
 ```
 

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -74,11 +74,11 @@ alloy_service_override_dir: "/etc/systemd/system/alloy.service.d"
 alloy_service_override_file: "/etc/systemd/system/alloy.service.d/override.conf"
 
 # Server configuration
-alloy_enable_web_server: true
-alloy_enable_grpc_server: false
+alloy_web_server_enabled: true
+alloy_grpc_server_enabled: false
 alloy_server_http_listen_address: "0.0.0.0"
 alloy_server_grpc_listen_address: "0.0.0.0"
-alloy_server_http_enable_pprof: false
+alloy_server_http_pprof_enabled: false
 alloy_server_grpc_max_recv_msg_size: ""
 alloy_server_grpc_max_send_msg_size: ""
 alloy_server_log_level: ""
@@ -94,7 +94,7 @@ alloy_cluster_discover_peers: ""
 alloy_cluster_rejoin_interval: ""
 
 # Prometheus configuration
-alloy_enable_prometheus: false
+alloy_prometheus_enabled: false
 alloy_prometheus_scrape_interval: ""
 alloy_prometheus_scrape_timeout: ""
 alloy_prometheus_metrics_path: ""
@@ -132,7 +132,7 @@ alloy_textfile_scripts: []
 #     on_boot_sec: "15s"                        # systemd OnBootSec
 
 # Loki configuration
-alloy_enable_loki: false
+alloy_loki_enabled: false
 alloy_loki_file_sources: []
 alloy_loki_journal_enabled: false
 alloy_loki_journal_matches: []
@@ -147,7 +147,7 @@ alloy_loki_clients:
       url: "http://localhost:3100/loki/api/v1/push"
 
 # OpenTelemetry configuration
-alloy_enable_otel: false
+alloy_otel_enabled: false
 alloy_otel_grpc_endpoint: "0.0.0.0:4317"
 alloy_otel_http_endpoint: "0.0.0.0:4318"
 alloy_otel_grpc_tls: {}
@@ -155,7 +155,7 @@ alloy_otel_http_tls: {}
 alloy_otel_traces_output: ""
 
 # OpenTelemetry processors
-alloy_enable_otel_processors: false
+alloy_otel_processors_enabled: false
 alloy_otel_processor_batch: {}
 alloy_otel_processor_attributes: {}
 alloy_otel_processor_resource: {}
@@ -164,8 +164,8 @@ alloy_otel_processor_resource: {}
 alloy_otel_exporters: []
 
 # Advanced node exporter and journal monitoring configuration
-alloy_enable_advanced_node_exporter: false
-alloy_enable_journal_monitoring: false
+alloy_advanced_node_exporter_enabled: false
+alloy_journal_monitoring_enabled: false
 alloy_node_exporter_metric_allowlist: []
 
 # Default node exporter configuration (can be overridden in group_vars)
@@ -213,7 +213,7 @@ alloy_journal_config:
           target_label: "level"
 
 # Grafana Remote Configuration
-alloy_enable_remotecfg: false
+alloy_remotecfg_enabled: false
 
 # Remote configuration using the remotecfg block
 # This is a single configuration object for the remotecfg block (can only appear once per config file)

--- a/roles/alloy/meta/argument_specs.yml
+++ b/roles/alloy/meta/argument_specs.yml
@@ -148,13 +148,13 @@ argument_specs:
                 default: "0.0.0.0"
                 description: "HTTP listen address for Grafana Alloy server"
 
-            alloy_enable_web_server: &alloy_enable_web_server
+            alloy_web_server_enabled: &alloy_web_server_enabled
                 type: "bool"
                 required: false
                 default: true
                 description: "Enable HTTP web server for Alloy UI and API"
 
-            alloy_enable_grpc_server: &alloy_enable_grpc_server
+            alloy_grpc_server_enabled: &alloy_grpc_server_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -166,7 +166,7 @@ argument_specs:
                 default: "0.0.0.0"
                 description: "gRPC listen address for Grafana Alloy server"
 
-            alloy_server_http_enable_pprof: &alloy_server_http_enable_pprof
+            alloy_server_http_pprof_enabled: &alloy_server_http_pprof_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -241,7 +241,7 @@ argument_specs:
                 default: ""
                 description: "Interval for cluster rejoin attempts"
 
-            alloy_enable_prometheus: &alloy_enable_prometheus
+            alloy_prometheus_enabled: &alloy_prometheus_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -633,7 +633,7 @@ argument_specs:
                         default: "15s"
                         description: "systemd OnBootSec= value."
 
-            alloy_enable_loki: &alloy_enable_loki
+            alloy_loki_enabled: &alloy_loki_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -753,7 +753,7 @@ argument_specs:
                         required: false
                         description: "Tenant ID for multi-tenant Loki instances"
 
-            alloy_enable_otel: &alloy_enable_otel
+            alloy_otel_enabled: &alloy_otel_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -789,7 +789,7 @@ argument_specs:
                 default: ""
                 description: "Output target for OpenTelemetry traces"
 
-            alloy_enable_otel_processors: &alloy_enable_otel_processors
+            alloy_otel_processors_enabled: &alloy_otel_processors_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -881,8 +881,8 @@ argument_specs:
                 description: "Version of the Grafana Alloy package"
 
             # Node exporter configuration options
-            alloy_enable_advanced_node_exporter:
-                &alloy_enable_advanced_node_exporter
+            alloy_advanced_node_exporter_enabled:
+                &alloy_advanced_node_exporter_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -1028,7 +1028,7 @@ argument_specs:
                 description: "List of metrics to keep, filtering out all others to reduce network and storage usage"
 
             # Grafana Remote Configuration options
-            alloy_enable_remotecfg: &alloy_enable_remotecfg
+            alloy_remotecfg_enabled: &alloy_remotecfg_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -1043,11 +1043,11 @@ argument_specs:
                     url:
                         # Not required at the spec level: alloy_remotecfg
                         # defaults to {} and the remotecfg module is only
-                        # rendered when alloy_enable_remotecfg is true, so a
+                        # rendered when alloy_remotecfg_enabled is true, so a
                         # required url here would reject the empty default.
                         type: "str"
                         required: false
-                        description: "The address of the API to poll for configuration (required when alloy_enable_remotecfg is true)"
+                        description: "The address of the API to poll for configuration (required when alloy_remotecfg_enabled is true)"
                     poll_frequency:
                         type: "str"
                         required: false
@@ -1144,7 +1144,7 @@ argument_specs:
                 default: {}
                 description: "Default queue configuration to prevent undefined variable errors"
 
-            alloy_enable_journal_monitoring: &alloy_enable_journal_monitoring
+            alloy_journal_monitoring_enabled: &alloy_journal_monitoring_enabled
                 type: "bool"
                 required: false
                 default: false
@@ -1235,7 +1235,7 @@ argument_specs:
                 default: ""
                 description: >-
                     Grafana Cloud Fleet Management username, rendered only when
-                    alloy_enable_remotecfg is true.
+                    alloy_remotecfg_enabled is true.
 
             alloy_grafana_cloud_fleet_token: &alloy_grafana_cloud_fleet_token
                 type: "str"
@@ -1244,7 +1244,7 @@ argument_specs:
                 no_log: true
                 description: >-
                     Grafana Cloud Fleet Management API token, rendered only when
-                    alloy_enable_remotecfg is true. Supply through Ansible Vault.
+                    alloy_remotecfg_enabled is true. Supply through Ansible Vault.
 
             alloy_no_log_env_file: &alloy_no_log_env_file
                 type: "bool"
@@ -1298,10 +1298,10 @@ argument_specs:
             alloy_log_level: *alloy_log_level
             alloy_log_format: *alloy_log_format
             alloy_server_http_listen_address: *alloy_server_http_listen_address
-            alloy_enable_web_server: *alloy_enable_web_server
-            alloy_enable_grpc_server: *alloy_enable_grpc_server
+            alloy_web_server_enabled: *alloy_web_server_enabled
+            alloy_grpc_server_enabled: *alloy_grpc_server_enabled
             alloy_server_grpc_listen_address: *alloy_server_grpc_listen_address
-            alloy_server_http_enable_pprof: *alloy_server_http_enable_pprof
+            alloy_server_http_pprof_enabled: *alloy_server_http_pprof_enabled
             alloy_server_log_source_ips: *alloy_server_log_source_ips
             alloy_server_grpc_max_recv_msg_size: *alloy_server_grpc_max_recv_msg_size
             alloy_server_grpc_max_send_msg_size: *alloy_server_grpc_max_send_msg_size
@@ -1313,7 +1313,7 @@ argument_specs:
             alloy_cluster_advertise_port: *alloy_cluster_advertise_port
             alloy_cluster_discover_peers: *alloy_cluster_discover_peers
             alloy_cluster_rejoin_interval: *alloy_cluster_rejoin_interval
-            alloy_enable_prometheus: *alloy_enable_prometheus
+            alloy_prometheus_enabled: *alloy_prometheus_enabled
             alloy_prometheus_scrape_interval: *alloy_prometheus_scrape_interval
             alloy_prometheus_scrape_timeout: *alloy_prometheus_scrape_timeout
             alloy_prometheus_metrics_path: *alloy_prometheus_metrics_path
@@ -1326,7 +1326,7 @@ argument_specs:
             alloy_textfile_collector_directory: *alloy_textfile_collector_directory
             alloy_textfile_script_directory: *alloy_textfile_script_directory
             alloy_textfile_scripts: *alloy_textfile_scripts
-            alloy_enable_loki: *alloy_enable_loki
+            alloy_loki_enabled: *alloy_loki_enabled
             alloy_loki_file_sources: *alloy_loki_file_sources
             alloy_loki_journal_enabled: *alloy_loki_journal_enabled
             alloy_loki_journal_matches: *alloy_loki_journal_matches
@@ -1335,18 +1335,18 @@ argument_specs:
             alloy_loki_journal_write_to: *alloy_loki_journal_write_to
             alloy_loki_process_configs: *alloy_loki_process_configs
             alloy_loki_clients: *alloy_loki_clients
-            alloy_enable_otel: *alloy_enable_otel
+            alloy_otel_enabled: *alloy_otel_enabled
             alloy_otel_grpc_endpoint: *alloy_otel_grpc_endpoint
             alloy_otel_http_endpoint: *alloy_otel_http_endpoint
             alloy_otel_grpc_tls: *alloy_otel_grpc_tls
             alloy_otel_http_tls: *alloy_otel_http_tls
             alloy_otel_traces_output: *alloy_otel_traces_output
-            alloy_enable_otel_processors: *alloy_enable_otel_processors
+            alloy_otel_processors_enabled: *alloy_otel_processors_enabled
             alloy_otel_processor_batch: *alloy_otel_processor_batch
             alloy_otel_processor_attributes: *alloy_otel_processor_attributes
             alloy_otel_processor_resource: *alloy_otel_processor_resource
             alloy_otel_exporters: *alloy_otel_exporters
-            alloy_enable_remotecfg: *alloy_enable_remotecfg
+            alloy_remotecfg_enabled: *alloy_remotecfg_enabled
             alloy_remotecfg: *alloy_remotecfg
             alloy_grafana_cloud_prometheus_user: *alloy_grafana_cloud_prometheus_user
             alloy_grafana_cloud_prometheus_token: *alloy_grafana_cloud_prometheus_token

--- a/roles/alloy/molecule/default/converge.yml
+++ b/roles/alloy/molecule/default/converge.yml
@@ -17,7 +17,7 @@
             # Prometheus: enable and define one scrape config so a
             # prometheus.scrape component is rendered. Forwards to the
             # default remote_write target shipped in role defaults.
-            alloy_enable_prometheus: true
+            alloy_prometheus_enabled: true
             alloy_prometheus_additional_scrape_configs:
                 - job_name: "self"
                   static_configs:
@@ -25,11 +25,11 @@
                   remote_write: "default"
 
             # Node exporter: renders prometheus.exporter.unix.
-            alloy_enable_advanced_node_exporter: true
+            alloy_advanced_node_exporter_enabled: true
 
             # Loki: enable and define one file source so a loki.source
             # component is rendered. Forwards to the default loki client.
-            alloy_enable_loki: true
+            alloy_loki_enabled: true
             alloy_loki_file_sources:
                 - name: "syslog"
                   targets:

--- a/roles/alloy/templates/etc/alloy/modules/journal.j2
+++ b/roles/alloy/templates/etc/alloy/modules/journal.j2
@@ -1,7 +1,7 @@
 {# Journal Monitoring Configuration Module #}
 {% from 'etc/alloy/macros/alloy_macros.j2' import relabel_rule %}
 
-{% if alloy_enable_journal_monitoring | default(false) %}
+{% if alloy_journal_monitoring_enabled | default(false) %}
 // Journal log collection with relabeling
 loki.relabel "integrations_node_exporter" {
   forward_to = [loki.write.{{ alloy_loki_clients[0].name | replace('-', '_') }}.receiver]

--- a/roles/alloy/templates/etc/alloy/modules/loki.j2
+++ b/roles/alloy/templates/etc/alloy/modules/loki.j2
@@ -1,7 +1,7 @@
 {# Loki Configuration Module #}
 {% from 'etc/alloy/macros/alloy_macros.j2' import tls_config, auth_options, external_labels, endpoint_config, relabel_rule, queue_config %}
 
-{% if alloy_enable_loki | default(false) %}
+{% if alloy_loki_enabled | default(false) %}
 // Loki Log Collection
 {% if alloy_loki_file_sources | default([]) | length > 0 %}
 {% for source in alloy_loki_file_sources %}

--- a/roles/alloy/templates/etc/alloy/modules/node_exporter.j2
+++ b/roles/alloy/templates/etc/alloy/modules/node_exporter.j2
@@ -8,7 +8,7 @@
 #}
 {% from 'etc/alloy/macros/alloy_macros.j2' import relabel_config, process_relabel_configs, external_labels %}
 
-{% if alloy_enable_advanced_node_exporter | default(false) %}
+{% if alloy_advanced_node_exporter_enabled | default(false) %}
 // Advanced Node Exporter with optimized configuration and relabeling
 
 // Node Exporter integration - embedded exporter with enterprise configuration

--- a/roles/alloy/templates/etc/alloy/modules/otel.j2
+++ b/roles/alloy/templates/etc/alloy/modules/otel.j2
@@ -1,7 +1,7 @@
 {# OpenTelemetry Configuration Module #}
 {% from 'etc/alloy/macros/alloy_macros.j2' import tls_config, auth_options, output_config %}
 
-{% if alloy_enable_otel | default(false) %}
+{% if alloy_otel_enabled | default(false) %}
 // OpenTelemetry Receiver (optional)
 otelcol.receiver.otlp "default" {
   grpc {
@@ -12,10 +12,10 @@ otelcol.receiver.otlp "default" {
     endpoint = "{{ alloy_otel_http_endpoint | default('0.0.0.0:4318') }}"
     {{ tls_config(alloy_otel_http_tls) }}
   }
-  {{ output_config(alloy_enable_prometheus | default(false), alloy_enable_loki | default(false), alloy_otel_traces_output | default('')) }}
+  {{ output_config(alloy_prometheus_enabled | default(false), alloy_loki_enabled | default(false), alloy_otel_traces_output | default('')) }}
 }
 
-{% if alloy_enable_otel_processors | default(false) %}
+{% if alloy_otel_processors_enabled | default(false) %}
 // OpenTelemetry Processors
 {% if alloy_otel_processor_batch | default('') | length > 0 %}
 otelcol.processor.batch "default" {
@@ -23,7 +23,7 @@ otelcol.processor.batch "default" {
   send_batch_size = {{ alloy_otel_processor_batch.send_batch_size | default(1024) }}
   send_batch_max_size = {{ alloy_otel_processor_batch.send_batch_max_size | default(2048) }}
 
-  {{ output_config(alloy_enable_prometheus | default(false), alloy_enable_loki | default(false), alloy_otel_traces_output | default('')) }}
+  {{ output_config(alloy_prometheus_enabled | default(false), alloy_loki_enabled | default(false), alloy_otel_traces_output | default('')) }}
 }
 {% endif %}
 
@@ -42,7 +42,7 @@ otelcol.processor.attributes "default" {
   }
   {% endfor %}
 
-  {{ output_config(alloy_enable_prometheus | default(false), alloy_enable_loki | default(false), alloy_otel_traces_output | default('')) }}
+  {{ output_config(alloy_prometheus_enabled | default(false), alloy_loki_enabled | default(false), alloy_otel_traces_output | default('')) }}
 }
 {% endif %}
 
@@ -56,7 +56,7 @@ otelcol.processor.resource "default" {
   }
   {% endfor %}
 
-  {{ output_config(alloy_enable_prometheus | default(false), alloy_enable_loki | default(false), alloy_otel_traces_output | default('')) }}
+  {{ output_config(alloy_prometheus_enabled | default(false), alloy_loki_enabled | default(false), alloy_otel_traces_output | default('')) }}
 }
 {% endif %}
 {% endif %}

--- a/roles/alloy/templates/etc/alloy/modules/prometheus.j2
+++ b/roles/alloy/templates/etc/alloy/modules/prometheus.j2
@@ -7,7 +7,7 @@
 #}
 {% from 'etc/alloy/macros/alloy_macros.j2' import tls_config, auth_options, external_labels, queue_config, metadata_config, endpoint_config, process_relabel_configs, relabel_config, authorization_block, basic_auth_block, oauth2_block, clustering_block %}
 
-{% if alloy_enable_prometheus | default(false) %}
+{% if alloy_prometheus_enabled | default(false) %}
 {% if alloy_prometheus_additional_scrape_configs | default([]) | length > 0 %}
 // Additional Prometheus scrape configurations
 {% for scrape_config in alloy_prometheus_additional_scrape_configs %}

--- a/roles/alloy/templates/etc/alloy/modules/remotecfg.j2
+++ b/roles/alloy/templates/etc/alloy/modules/remotecfg.j2
@@ -1,6 +1,6 @@
 {# Grafana Remote Configuration Module #}
 
-{% if alloy_enable_remotecfg | default(false) and alloy_remotecfg is defined %}
+{% if alloy_remotecfg_enabled | default(false) and alloy_remotecfg is defined %}
 // Grafana Alloy remote configuration management
 remotecfg {
   url = "{{ alloy_remotecfg.url }}"

--- a/roles/alloy/templates/etc/default/alloy.j2
+++ b/roles/alloy/templates/etc/default/alloy.j2
@@ -33,7 +33,7 @@ GRAFANA_CLOUD_LOKI_USER={{ alloy_grafana_cloud_loki_user | default('') }}
 {% endif %}
 
 # Grafana Remote Configuration credentials
-{% if alloy_enable_remotecfg | default(false) %}
+{% if alloy_remotecfg_enabled | default(false) %}
 {% if alloy_grafana_cloud_fleet_user | default('') | length > 0 %}
 GRAFANA_CLOUD_FLEET_USER={{ alloy_grafana_cloud_fleet_user }}
 {% endif %}

--- a/roles/alloy/templates/etc/systemd/system/alloy.service.d/override.conf.j2
+++ b/roles/alloy/templates/etc/systemd/system/alloy.service.d/override.conf.j2
@@ -8,7 +8,7 @@ Group={{ alloy_group }}
 
 # Override configuration file path
 ExecStart=
-ExecStart=/usr/bin/alloy run {{ alloy_config_file }} --storage.path={{ alloy_storage_path }}{% if alloy_enable_web_server | default(true) %} --server.http.listen-addr={{ alloy_server_http_listen_address | default('0.0.0.0') }}:{{ alloy_port | default('12345') }}{% endif %}{% if alloy_enable_grpc_server | default(false) %} --server.grpc.listen-addr={{ alloy_server_grpc_listen_address | default('0.0.0.0') }}:{{ alloy_grpc_port | default('12346') }}{% endif %}
+ExecStart=/usr/bin/alloy run {{ alloy_config_file }} --storage.path={{ alloy_storage_path }}{% if alloy_web_server_enabled | default(true) %} --server.http.listen-addr={{ alloy_server_http_listen_address | default('0.0.0.0') }}:{{ alloy_port | default('12345') }}{% endif %}{% if alloy_grpc_server_enabled | default(false) %} --server.grpc.listen-addr={{ alloy_server_grpc_listen_address | default('0.0.0.0') }}:{{ alloy_grpc_port | default('12346') }}{% endif %}
 
 # Override environment file
 EnvironmentFile={{ alloy_env_file }}

--- a/roles/do/defaults/main.yml
+++ b/roles/do/defaults/main.yml
@@ -16,9 +16,9 @@ do_storage_path: "/var/lib/do-agent"
 do_custom_config_enabled: false
 
 # Feature flags
-do_enable_metrics: true
-do_enable_logs: true
-do_enable_insights: true
+do_metrics_enabled: true
+do_logs_enabled: true
+do_insights_enabled: true
 
 # Optional API configuration
 do_api_token: ""

--- a/roles/do/meta/argument_specs.yml
+++ b/roles/do/meta/argument_specs.yml
@@ -88,19 +88,19 @@ argument_specs:
                     no_log toggle for the token-rendering tasks; set false to
                     surface a template error hidden as 'non-zero return code'.
 
-            do_enable_metrics:
+            do_metrics_enabled:
                 type: "bool"
                 required: false
                 default: true
                 description: "Enables metrics collection"
 
-            do_enable_logs:
+            do_logs_enabled:
                 type: "bool"
                 required: false
                 default: true
                 description: "Enables log collection"
 
-            do_enable_insights:
+            do_insights_enabled:
                 type: "bool"
                 required: false
                 default: true

--- a/tests/unit/test_alloy_env_template.py
+++ b/tests/unit/test_alloy_env_template.py
@@ -54,7 +54,7 @@ def render(**overrides):
 
 def test_prefixed_credentials_render():
     """The prefixed variables reach the rendered environment file."""
-    output = render(**CREDENTIAL_VARS, alloy_enable_remotecfg=True)
+    output = render(**CREDENTIAL_VARS, alloy_remotecfg_enabled=True)
 
     assert "GRAFANA_CLOUD_PROMETHEUS_TOKEN=rendered-prometheus-credential" in output
     assert "GRAFANA_CLOUD_PROMETHEUS_USER=rendered-prometheus-username" in output
@@ -74,14 +74,14 @@ def test_template_reads_no_unprefixed_names():
 def test_legacy_names_are_ignored():
     """Values supplied under the old names do not reach the output."""
     legacy_values = {name: f"legacy-{name}" for name in LEGACY_NAMES}
-    output = render(**legacy_values, alloy_enable_remotecfg=True)
+    output = render(**legacy_values, alloy_remotecfg_enabled=True)
 
     assert "legacy-" not in output
 
 
 def test_credentials_omitted_when_unset():
     """Without credentials the token keys are absent, not rendered empty."""
-    output = render(alloy_enable_remotecfg=True)
+    output = render(alloy_remotecfg_enabled=True)
 
     assert "GRAFANA_CLOUD_PROMETHEUS_TOKEN" not in output
     assert "GRAFANA_CLOUD_LOKI_TOKEN" not in output
@@ -110,15 +110,15 @@ def test_credentials_omitted_when_unset():
 )
 def test_placeholder_values_are_suppressed(variable, placeholder, key):
     """The shipped placeholder values never reach the environment file."""
-    output = render(**{variable: placeholder}, alloy_enable_remotecfg=True)
+    output = render(**{variable: placeholder}, alloy_remotecfg_enabled=True)
 
     assert key not in output
 
 
 def test_fleet_credentials_require_remotecfg():
     """Fleet credentials render only when remotecfg is enabled."""
-    disabled = render(**CREDENTIAL_VARS, alloy_enable_remotecfg=False)
-    enabled = render(**CREDENTIAL_VARS, alloy_enable_remotecfg=True)
+    disabled = render(**CREDENTIAL_VARS, alloy_remotecfg_enabled=False)
+    enabled = render(**CREDENTIAL_VARS, alloy_remotecfg_enabled=True)
 
     assert "GRAFANA_CLOUD_FLEET_TOKEN" not in disabled
     assert "GRAFANA_CLOUD_FLEET_TOKEN=rendered-fleet-credential" in enabled
@@ -127,7 +127,7 @@ def test_fleet_credentials_require_remotecfg():
 
 def test_base_settings_render_without_credentials():
     """The non-credential part of the file is independent of the migration."""
-    output = render(alloy_enable_remotecfg=False)
+    output = render(alloy_remotecfg_enabled=False)
 
     assert "ALLOY_LOG_LEVEL=info" in output
     assert "ALLOY_SERVER_HTTP_LISTEN_ADDRESS=127.0.0.1:12345" in output


### PR DESCRIPTION
## Summary

- Renames 13 boolean variables in the `alloy` and `do` roles from the `*_enable_*` prefix form to the `*_enabled` suffix form, matching the `tailscale` role.
- Fixes the `alloy` README Quick Start, which documented `alloy_prometheus_enabled`, `alloy_node_exporter_enabled` and `alloy_loki_enabled` — none of which existed. Copying it produced an Alloy with nothing enabled and no error.
- Breaking without a deprecation alias: an alias would point the wrong way and be overridden whenever a user sets the old name in `vars:`. `galaxy.yml` goes to `2.0.0`; the CHANGELOG carries the full migration table.
- The `enable_start_time_metrics`, `enable_task_metrics` and `enable_restarts_metrics` keys inside `alloy_node_exporter_config.systemd` are upstream Alloy configuration and keep their names.

## Test plan

- [ ] CI green (alloy and multi-role Molecule scenarios are the functional proof)
- [ ] No old name survives: `grep -rn "alloy_enable_\|do_enable_\|alloy_server_http_enable_pprof" --exclude-dir=.git --exclude=CHANGELOG.md .` returns nothing
- [ ] Every new name is declared in both `defaults/main.yml` and `meta/argument_specs.yml` of its role
- [ ] `argument_specs.yml` still parses — anchors and aliases were renamed together, including the key/anchor pair split across two lines
- [ ] `yamllint -c .yamllint .` clean