### PR TITLE
refactor: add <role>_enabled master switches and fix the tailscale_enabled collision

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
             driver: qemu
             python_version: "3.13"
             scenarios_root: roles/alloy/molecule
-            scenarios: '["default"]'
+            scenarios: '["default","disabled"]'
             concurrency-suffix: molecule-alloy
 
     molecule-do:
@@ -55,7 +55,7 @@ jobs:
             driver: docker
             python_version: "3.13"
             scenarios_root: roles/do/molecule
-            scenarios: '["default"]'
+            scenarios: '["default","disabled"]'
             concurrency-suffix: molecule-do
 
     molecule-tailscale:
@@ -66,7 +66,7 @@ jobs:
             driver: docker
             python_version: "3.13"
             scenarios_root: roles/tailscale/molecule
-            scenarios: '["default"]'
+            scenarios: '["default","disabled"]'
             concurrency-suffix: molecule-tailscale
 
     molecule-multi-role:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Master switches (all roles)**: `alloy_enabled`, `do_enabled`, and
+  `tailscale_enabled` (all `bool`, default `true`) gate every dispatcher
+  include in the respective `tasks/main.yml`. Setting one to `false` skips
+  the whole role instead of requiring per-task `when` conditions.
+
 ### Removed
 
 - **Alloy (breaking)**: the six unprefixed Grafana Cloud variables the role read
@@ -84,7 +91,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     The `enable_start_time_metrics`, `enable_task_metrics` and
     `enable_restarts_metrics` keys inside `alloy_node_exporter_config.systemd`
     are upstream Alloy configuration and are unchanged. The `tailscale` role
-    already used the suffix form and is untouched.
+    already used the suffix form and is untouched by this rename — see the
+    separate `tailscale_daemon_enabled` entry below.
+
+- **BREAKING — Tailscale**: the daemon config key `tailscale_enabled` is
+  renamed to `tailscale_daemon_enabled`. It still sets `"enabled"` in
+  `/etc/tailscale/config.json` and keeps its `str` type and empty default.
+  The freed name `tailscale_enabled` is now the role master switch (`bool`,
+  default `true`). Anyone who set `tailscale_enabled` to control the daemon
+  config must rename it to `tailscale_daemon_enabled`; leaving it in place
+  no longer writes the daemon config and instead toggles the whole role.
 
 - **Renovate**: the custom regex manager now also scans
   `roles/*/meta/argument_specs.yml`, and the `*_version` defaults in the

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -2,6 +2,9 @@
 # Default variables for Alloy role
 # These variables can be overridden in group_vars or host_vars
 
+# Master switch: set to false to skip the role entirely
+alloy_enabled: true
+
 # OS-specific variable mappings - these map internal vars to public API
 # Dynamic variable assignment based on OS family using hierarchical structure
 alloy_package_dependencies: "{{ _alloy_os[ansible_os_family].package_dependencies }}"

--- a/roles/alloy/meta/argument_specs.yml
+++ b/roles/alloy/meta/argument_specs.yml
@@ -10,6 +10,12 @@ argument_specs:
             for collecting, transforming, and forwarding telemetry data.
         author: "Simon Bärlocher"
         options:
+            alloy_enabled:
+                type: "bool"
+                required: false
+                default: true
+                description: "Master switch: set to false to skip the role entirely"
+
             # Common options
             alloy_user: &alloy_user
                 type: "str"

--- a/roles/alloy/molecule/disabled/converge.yml
+++ b/roles/alloy/molecule/disabled/converge.yml
@@ -1,0 +1,12 @@
+---
+# Molecule converge playbook for the Grafana Alloy master switch
+- name: Converge
+  hosts: all
+  become: true
+
+  roles:
+      - role: arillso.agent.alloy
+        vars:
+            # The whole point of this scenario: with the master switch off
+            # the role must not touch the host at all.
+            alloy_enabled: false

--- a/roles/alloy/molecule/disabled/molecule.yml
+++ b/roles/alloy/molecule/disabled/molecule.yml
@@ -1,0 +1,56 @@
+---
+dependency:
+    name: galaxy
+    options:
+        requirements-file: requirements.yml
+
+driver:
+    name: molecule-qemu
+
+# One platform only: this scenario asserts that nothing happens, which is
+# OS-independent, and qemu is the most expensive driver in this repo.
+# The SSH port differs from the default scenario (2222/2223) to avoid a
+# collision when both scenarios run on the same runner.
+platforms:
+    - name: alloy-disabled-debian12
+      image_url: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+      image_checksum: sha512:https://cloud.debian.org/images/cloud/bookworm/latest/SHA512SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2224
+      network_ssh_user: debian
+      vm_cpus: 2
+      vm_memory: 2048
+
+provisioner:
+    name: ansible
+    config_options:
+        defaults:
+            interpreter_python: auto_silent
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
+    inventory:
+        host_vars:
+            alloy-disabled-debian12:
+                # debian cloud images log in as `debian`; the role needs root.
+                ansible_become: true
+
+verifier:
+    name: ansible
+
+scenario:
+    name: disabled
+    test_sequence:
+        - dependency
+        - cleanup
+        - destroy
+        - syntax
+        - create
+        - prepare
+        - converge
+        - idempotence
+        - side_effect
+        - verify
+        - cleanup
+        - destroy

--- a/roles/alloy/molecule/disabled/requirements.yml
+++ b/roles/alloy/molecule/disabled/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+    - name: arillso.system
+      version: ">=1.0.0"

--- a/roles/alloy/molecule/disabled/side_effect.yml
+++ b/roles/alloy/molecule/disabled/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/alloy/molecule/disabled/verify.yml
+++ b/roles/alloy/molecule/disabled/verify.yml
@@ -1,0 +1,42 @@
+---
+# Molecule verify playbook for the Grafana Alloy master switch
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: true
+
+  tasks:
+      - name: Gather installed packages
+        ansible.builtin.package_facts:
+            manager: auto
+
+      - name: Assert Alloy package is not installed
+        ansible.builtin.assert:
+            that:
+                - "'alloy' not in ansible_facts.packages"
+            fail_msg: "Alloy package was installed despite alloy_enabled: false"
+            success_msg: "Alloy package is not installed"
+
+      - name: Check the Alloy configuration file
+        ansible.builtin.stat:
+            path: /etc/alloy/config.alloy
+        register: alloy_disabled_config
+
+      - name: Assert the Alloy configuration file was not written
+        ansible.builtin.assert:
+            that:
+                - not alloy_disabled_config.stat.exists
+            fail_msg: "Alloy config was written despite alloy_enabled: false"
+            success_msg: "Alloy config was not written"
+
+      - name: Check the Alloy systemd override directory
+        ansible.builtin.stat:
+            path: /etc/systemd/system/alloy.service.d
+        register: alloy_disabled_override
+
+      - name: Assert the Alloy systemd override was not deployed
+        ansible.builtin.assert:
+            that:
+                - not alloy_disabled_override.stat.exists
+            fail_msg: "Alloy systemd override was deployed despite alloy_enabled: false"
+            success_msg: "Alloy systemd override was not deployed"

--- a/roles/alloy/tasks/main.yml
+++ b/roles/alloy/tasks/main.yml
@@ -2,26 +2,29 @@
 # Main tasks for Alloy role
 # This file orchestrates the installation and configuration of Grafana Alloy
 
-- name: Include installation tasks
-  ansible.builtin.include_tasks: install.yml
-  tags:
-      - alloy
-      - install
+- name: Run Alloy role tasks
+  when: alloy_enabled | bool
+  block:
+      - name: Include installation tasks
+        ansible.builtin.include_tasks: install.yml
+        tags:
+            - alloy
+            - install
 
-- name: Include configuration tasks
-  ansible.builtin.include_tasks: configure.yml
-  tags:
-      - alloy
-      - configure
+      - name: Include configuration tasks
+        ansible.builtin.include_tasks: configure.yml
+        tags:
+            - alloy
+            - configure
 
-- name: Include service management tasks
-  ansible.builtin.include_tasks: service.yml
-  tags:
-      - alloy
-      - service
+      - name: Include service management tasks
+        ansible.builtin.include_tasks: service.yml
+        tags:
+            - alloy
+            - service
 
-- name: Include textfile collector script deployment
-  ansible.builtin.include_tasks: textfile.yml
-  tags:
-      - alloy
-      - textfile
+      - name: Include textfile collector script deployment
+        ansible.builtin.include_tasks: textfile.yml
+        tags:
+            - alloy
+            - textfile

--- a/roles/do/defaults/main.yml
+++ b/roles/do/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # Default variables for DigitalOcean Agent role
 
+# Master switch: set to false to skip the role entirely
+do_enabled: true
+
 # Package configuration
 do_package_name: "do-agent"
 # renovate: datasource=github-releases depName=digitalocean/do-agent

--- a/roles/do/meta/argument_specs.yml
+++ b/roles/do/meta/argument_specs.yml
@@ -10,6 +10,12 @@ argument_specs:
             for monitoring and observability of DigitalOcean Droplets.
         author: "Simon Bärlocher"
         options:
+            do_enabled:
+                type: "bool"
+                required: false
+                default: true
+                description: "Master switch: set to false to skip the role entirely"
+
             do_package_name:
                 type: "str"
                 required: false

--- a/roles/do/molecule/disabled/converge.yml
+++ b/roles/do/molecule/disabled/converge.yml
@@ -1,0 +1,12 @@
+---
+# Molecule converge playbook for the DigitalOcean Agent master switch
+- name: Converge
+  hosts: all
+  become: true
+
+  roles:
+      - role: arillso.agent.do
+        vars:
+            # The whole point of this scenario: with the master switch off
+            # the role must not touch the host at all.
+            do_enabled: false

--- a/roles/do/molecule/disabled/molecule.yml
+++ b/roles/do/molecule/disabled/molecule.yml
@@ -1,0 +1,50 @@
+---
+dependency:
+    name: galaxy
+
+driver:
+    name: docker
+
+# One platform only: this scenario asserts that nothing happens, which is
+# OS-independent.
+platforms:
+    - name: do-disabled-debian12
+      image: geerlingguy/docker-debian12-ansible:latest
+      command: ""
+      volumes:
+          - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      cgroupns_mode: host
+      privileged: true
+      pre_build_image: true
+
+provisioner:
+    name: ansible
+    config_options:
+        defaults:
+            interpreter_python: auto_silent
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
+    inventory:
+        host_vars:
+            do-disabled-debian12:
+                ansible_user: root
+
+verifier:
+    name: ansible
+
+scenario:
+    name: disabled
+    test_sequence:
+        - dependency
+        - cleanup
+        - destroy
+        - syntax
+        - create
+        - prepare
+        - converge
+        - idempotence
+        - side_effect
+        - verify
+        - cleanup
+        - destroy

--- a/roles/do/molecule/disabled/side_effect.yml
+++ b/roles/do/molecule/disabled/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/do/molecule/disabled/verify.yml
+++ b/roles/do/molecule/disabled/verify.yml
@@ -1,0 +1,42 @@
+---
+# Molecule verify playbook for the DigitalOcean Agent master switch
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: true
+
+  tasks:
+      - name: Gather installed packages
+        ansible.builtin.package_facts:
+            manager: auto
+
+      - name: Assert DO Agent package is not installed
+        ansible.builtin.assert:
+            that:
+                - "'do-agent' not in ansible_facts.packages"
+            fail_msg: "DO Agent package was installed despite do_enabled: false"
+            success_msg: "DO Agent package is not installed"
+
+      - name: Check the DO Agent configuration directory
+        ansible.builtin.stat:
+            path: /etc/do-agent
+        register: do_disabled_config_dir
+
+      - name: Assert the DO Agent configuration directory was not created
+        ansible.builtin.assert:
+            that:
+                - not do_disabled_config_dir.stat.exists
+            fail_msg: "DO Agent config directory was created despite do_enabled: false"
+            success_msg: "DO Agent config directory was not created"
+
+      - name: Check the DO Agent environment file
+        ansible.builtin.stat:
+            path: /etc/default/do-agent
+        register: do_disabled_env_file
+
+      - name: Assert the DO Agent environment file was not written
+        ansible.builtin.assert:
+            that:
+                - not do_disabled_env_file.stat.exists
+            fail_msg: "DO Agent environment file was written despite do_enabled: false"
+            success_msg: "DO Agent environment file was not written"

--- a/roles/do/tasks/main.yml
+++ b/roles/do/tasks/main.yml
@@ -2,26 +2,29 @@
 # Main tasks for DigitalOcean role
 # Diese Datei orchestriert die Installation und Konfiguration von DigitalOcean Agent
 
-- name: Load OS-specific variables
-  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
-  tags:
-      - do
-      - install
+- name: Run DigitalOcean Agent role tasks
+  when: do_enabled | bool
+  block:
+      - name: Load OS-specific variables
+        ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+        tags:
+            - do
+            - install
 
-- name: Include installation tasks
-  ansible.builtin.include_tasks: install.yml
-  tags:
-      - do
-      - install
+      - name: Include installation tasks
+        ansible.builtin.include_tasks: install.yml
+        tags:
+            - do
+            - install
 
-- name: Include configuration tasks
-  ansible.builtin.include_tasks: configure.yml
-  tags:
-      - do
-      - configure
+      - name: Include configuration tasks
+        ansible.builtin.include_tasks: configure.yml
+        tags:
+            - do
+            - configure
 
-- name: Include service management tasks
-  ansible.builtin.include_tasks: service.yml
-  tags:
-      - do
-      - service
+      - name: Include service management tasks
+        ansible.builtin.include_tasks: service.yml
+        tags:
+            - do
+            - service

--- a/roles/tailscale/defaults/main.yml
+++ b/roles/tailscale/defaults/main.yml
@@ -4,6 +4,9 @@ tailscale_package_state: present
 # renovate: datasource=github-releases depName=tailscale/tailscale extractVersion=^v(?<version>.*)$
 tailscale_version: "1.102.1"
 
+# Master switch: set to false to skip the role entirely
+tailscale_enabled: true
+
 tailscale_service_state: started
 tailscale_service_enabled: true
 
@@ -37,7 +40,7 @@ tailscale_service_override:
 
 tailscale_server_url: ""
 tailscale_locked: ""
-tailscale_enabled: ""
+tailscale_daemon_enabled: ""
 tailscale_hostname: ""
 tailscale_operator_user: ""
 

--- a/roles/tailscale/meta/argument_specs.yml
+++ b/roles/tailscale/meta/argument_specs.yml
@@ -11,6 +11,12 @@ argument_specs:
             All configuration is persistent via /etc/tailscale/config.json daemon config file.
         author: "Simon Bärlocher"
         options:
+            tailscale_enabled:
+                type: "bool"
+                required: false
+                default: true
+                description: "Master switch: set to false to skip the role entirely"
+
             # Package and Service Configuration
             tailscale_package_name:
                 type: "str"
@@ -137,11 +143,11 @@ argument_specs:
                 default: ""
                 description: "Lock config to prevent CLI changes (true/false)"
 
-            tailscale_enabled:
+            tailscale_daemon_enabled:
                 type: "str"
                 required: false
                 default: ""
-                description: "Enable/disable Tailscale (true/false)"
+                description: "Daemon config key: sets 'enabled' in config.json (true/false)"
 
             tailscale_hostname:
                 type: "str"

--- a/roles/tailscale/molecule/default/converge.yml
+++ b/roles/tailscale/molecule/default/converge.yml
@@ -25,3 +25,8 @@
             # Basic settings for testing
             tailscale_accept_routes: true
             tailscale_ssh_enabled: false
+
+            # Daemon config key (renamed from tailscale_enabled, which is
+            # now the role master switch): must render as "enabled" in
+            # /etc/tailscale/config.json.
+            tailscale_daemon_enabled: true

--- a/roles/tailscale/molecule/default/verify.yml
+++ b/roles/tailscale/molecule/default/verify.yml
@@ -79,6 +79,18 @@
             fail_msg: "Systemd override directory does not exist"
             success_msg: "Systemd override directory exists"
 
+      - name: Read the Tailscale daemon configuration file
+        ansible.builtin.slurp:
+            src: /etc/tailscale/config.json
+        register: tailscale_daemon_config
+
+      - name: Assert tailscale_daemon_enabled rendered into the daemon config
+        ansible.builtin.assert:
+            that:
+                - (tailscale_daemon_config.content | b64decode | from_json).enabled | bool
+            fail_msg: 'tailscale_daemon_enabled did not render as "enabled" in config.json'
+            success_msg: 'tailscale_daemon_enabled rendered as "enabled" in config.json'
+
       - name: Check if Ansible facts script exists
         ansible.builtin.stat:
             path: /etc/ansible/facts.d/tailscale.fact

--- a/roles/tailscale/molecule/disabled/converge.yml
+++ b/roles/tailscale/molecule/disabled/converge.yml
@@ -1,0 +1,14 @@
+---
+# Molecule converge playbook for the Tailscale master switch
+- name: Converge
+  hosts: all
+  become: true
+
+  roles:
+      - role: arillso.agent.tailscale
+        vars:
+            # The whole point of this scenario: with the master switch off
+            # the role must not touch the host at all. tailscale_auth_key is
+            # deliberately left unset — that the validation assert does not
+            # fire when the role is disabled is part of what this proves.
+            tailscale_enabled: false

--- a/roles/tailscale/molecule/disabled/molecule.yml
+++ b/roles/tailscale/molecule/disabled/molecule.yml
@@ -1,0 +1,52 @@
+---
+dependency:
+    name: galaxy
+    options:
+        requirements-file: requirements.yml
+
+driver:
+    name: docker
+
+# One platform only: this scenario asserts that nothing happens, which is
+# OS-independent.
+platforms:
+    - name: tailscale-disabled-debian12
+      image: geerlingguy/docker-debian12-ansible:latest
+      command: ""
+      volumes:
+          - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      cgroupns_mode: host
+      privileged: true
+      pre_build_image: true
+
+provisioner:
+    name: ansible
+    config_options:
+        defaults:
+            interpreter_python: auto_silent
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
+            result_format: yaml
+    inventory:
+        host_vars:
+            tailscale-disabled-debian12:
+                ansible_user: root
+
+verifier:
+    name: ansible
+
+scenario:
+    name: disabled
+    test_sequence:
+        - dependency
+        - cleanup
+        - destroy
+        - syntax
+        - create
+        - prepare
+        - converge
+        - idempotence
+        - side_effect
+        - verify
+        - cleanup
+        - destroy

--- a/roles/tailscale/molecule/disabled/requirements.yml
+++ b/roles/tailscale/molecule/disabled/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+    - name: arillso.system
+      version: ">=1.0.0"

--- a/roles/tailscale/molecule/disabled/side_effect.yml
+++ b/roles/tailscale/molecule/disabled/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effect
+  hosts: all
+  gather_facts: false
+
+  tasks:
+      - name: No side-effect step required for this role
+        ansible.builtin.debug:
+            msg: "No side-effect step required."

--- a/roles/tailscale/molecule/disabled/verify.yml
+++ b/roles/tailscale/molecule/disabled/verify.yml
@@ -1,0 +1,42 @@
+---
+# Molecule verify playbook for the Tailscale master switch
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: true
+
+  tasks:
+      - name: Gather installed packages
+        ansible.builtin.package_facts:
+            manager: auto
+
+      - name: Assert Tailscale package is not installed
+        ansible.builtin.assert:
+            that:
+                - "'tailscale' not in ansible_facts.packages"
+            fail_msg: "Tailscale package was installed despite tailscale_enabled: false"
+            success_msg: "Tailscale package is not installed"
+
+      - name: Check the Tailscale configuration directory
+        ansible.builtin.stat:
+            path: /etc/tailscale
+        register: tailscale_disabled_config_dir
+
+      - name: Assert the Tailscale configuration directory was not created
+        ansible.builtin.assert:
+            that:
+                - not tailscale_disabled_config_dir.stat.exists
+            fail_msg: "Tailscale config directory was created despite tailscale_enabled: false"
+            success_msg: "Tailscale config directory was not created"
+
+      - name: Check the Tailscale local facts script
+        ansible.builtin.stat:
+            path: /etc/ansible/facts.d/tailscale.fact
+        register: tailscale_disabled_facts_script
+
+      - name: Assert the Tailscale local facts script was not deployed
+        ansible.builtin.assert:
+            that:
+                - not tailscale_disabled_facts_script.stat.exists
+            fail_msg: "Tailscale facts script was deployed despite tailscale_enabled: false"
+            success_msg: "Tailscale facts script was not deployed"

--- a/roles/tailscale/tasks/configure.yml
+++ b/roles/tailscale/tasks/configure.yml
@@ -22,7 +22,7 @@
           {{
             (tailscale_server_url | default('') | string | length > 0) or
             (tailscale_locked | default('') | string | length > 0) or
-            (tailscale_enabled | default('') | string | length > 0) or
+            (tailscale_daemon_enabled | default('') | string | length > 0) or
             (tailscale_hostname | default('') | string | length > 0) or
             (tailscale_operator_user | default('') | string | length > 0) or
             (tailscale_accept_dns | default('') | string | length > 0) or

--- a/roles/tailscale/tasks/main.yml
+++ b/roles/tailscale/tasks/main.yml
@@ -2,43 +2,46 @@
 # Tailscale VPN Agent Installation and Configuration
 # Main tasks for Tailscale installation and configuration
 
-- name: Display detected OS and Tailscale configuration
-  ansible.builtin.debug:
-      msg:
-          - "Detected OS: {{ ansible_distribution }} {{ ansible_distribution_version }}"
-          - "OS Family: {{ ansible_os_family }}"
-          - "Version Key: {{ tailscale_version_key }}"
-          - "Repository URL: {{ tailscale_repo_url }}"
-          - "GPG Key URL: {{ tailscale_gpg_key_url }}"
-          - "Repository Codename: {{ tailscale_repo_codename }}"
-          - "Package Only Mode: {{ tailscale_package_only }}"
-  tags: [tailscale, debug]
+- name: Run Tailscale role tasks
+  when: tailscale_enabled | bool
+  block:
+      - name: Display detected OS and Tailscale configuration
+        ansible.builtin.debug:
+            msg:
+                - "Detected OS: {{ ansible_distribution }} {{ ansible_distribution_version }}"
+                - "OS Family: {{ ansible_os_family }}"
+                - "Version Key: {{ tailscale_version_key }}"
+                - "Repository URL: {{ tailscale_repo_url }}"
+                - "GPG Key URL: {{ tailscale_gpg_key_url }}"
+                - "Repository Codename: {{ tailscale_repo_codename }}"
+                - "Package Only Mode: {{ tailscale_package_only }}"
+        tags: [tailscale, debug]
 
-- name: Validate tailscale configuration
-  ansible.builtin.assert:
-      that:
-          - tailscale_auth_key is defined
-      fail_msg: "tailscale_auth_key must be defined (may be empty to install without authenticating)"
-      success_msg: "Tailscale configuration is valid"
-  tags: [tailscale, validation]
+      - name: Validate tailscale configuration
+        ansible.builtin.assert:
+            that:
+                - tailscale_auth_key is defined
+            fail_msg: "tailscale_auth_key must be defined (may be empty to install without authenticating)"
+            success_msg: "Tailscale configuration is valid"
+        tags: [tailscale, validation]
 
-- name: Install Tailscale repository and package
-  ansible.builtin.include_tasks: install.yml
-  tags: [tailscale, install]
+      - name: Install Tailscale repository and package
+        ansible.builtin.include_tasks: install.yml
+        tags: [tailscale, install]
 
-- name: Manage Tailscale service state
-  ansible.builtin.include_tasks: service.yml
-  tags: [tailscale, service]
+      - name: Manage Tailscale service state
+        ansible.builtin.include_tasks: service.yml
+        tags: [tailscale, service]
 
-- name: Configure Tailscale service
-  ansible.builtin.include_tasks: configure.yml
-  tags: [tailscale, config]
+      - name: Configure Tailscale service
+        ansible.builtin.include_tasks: configure.yml
+        tags: [tailscale, config]
 
-- name: Setup Tailscale local facts
-  ansible.builtin.include_tasks: facts.yml
-  tags: [tailscale, facts]
+      - name: Setup Tailscale local facts
+        ansible.builtin.include_tasks: facts.yml
+        tags: [tailscale, facts]
 
-- name: Verify Tailscale connectivity
-  ansible.builtin.include_tasks: verify.yml
-  when: tailscale_verify_connectivity | default(true) | bool
-  tags: [tailscale, verify]
+      - name: Verify Tailscale connectivity
+        ansible.builtin.include_tasks: verify.yml
+        when: tailscale_verify_connectivity | default(true) | bool
+        tags: [tailscale, verify]

--- a/roles/tailscale/templates/etc/tailscale/config.json.j2
+++ b/roles/tailscale/templates/etc/tailscale/config.json.j2
@@ -13,8 +13,8 @@
 {%- if tailscale_locked is defined and tailscale_locked != '' -%}
   {%- set _ = config.update({"locked": tailscale_locked | bool}) -%}
 {%- endif -%}
-{%- if tailscale_enabled is defined and tailscale_enabled != '' -%}
-  {%- set _ = config.update({"enabled": tailscale_enabled | bool}) -%}
+{%- if tailscale_daemon_enabled is defined and tailscale_daemon_enabled != '' -%}
+  {%- set _ = config.update({"enabled": tailscale_daemon_enabled | bool}) -%}
 {%- endif -%}
 {%- if tailscale_hostname | default('') | length > 0 -%}
   {%- set _ = config.update({"hostname": tailscale_hostname}) -%}


### PR DESCRIPTION
## Summary

- Add `alloy_enabled`, `do_enabled` and `tailscale_enabled` (all `bool`, default `true`) and gate every dispatcher include in the respective `tasks/main.yml` on them, so a role can be skipped as a whole. For `do` the OS variable load moves inside the block; for `tailscale` the debug task and the auth-key assert do too, since asserting on an auth key for a disabled role would be wrong.
- **Breaking:** `tailscale_enabled` was not a master switch but the daemon config key for the JSON field `"enabled"`. Setting it to `false` wrote `"enabled": false` into the daemon config while every task kept running. It is renamed to `tailscale_daemon_enabled` (unchanged `str` type, empty default) and the freed name is now the role master switch. Documented in the CHANGELOG under `### Changed`.
- Each role gets a `disabled` molecule scenario asserting that no package, config or unit appears when the switch is off, wired into the CI matrix. The tailscale `default` scenario now also asserts the renamed daemon key still renders into `/etc/tailscale/config.json`, which would otherwise be untested.

## Test plan

- [ ] `molecule test -s disabled` per role (alloy, do, tailscale) — asserts nothing is installed or written when the switch is off
- [ ] `molecule test -s default` for tailscale — asserts `tailscale_daemon_enabled: true` renders as `"enabled": true` in the daemon config
- [ ] `molecule test -s multi-role` unchanged and still green
- [ ] `make lint` (ansible-lint, yamllint) and the full CI matrix green