### PR TITLE
refactor(handlers)!: namespace handler listen topics per role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING — handler topic namespacing (`alloy`, `do`, `tailscale`)**: all
+  handler `listen:` topics are now prefixed with their role. The three roles
+  each listened on the bare topic `reload systemd`, so loading them in one play
+  made a single `notify` fire the handlers of all three. A `notify` to a topic
+  with no matching handler is ignored rather than an error, so consumer plays
+  notifying the old bare topics silently stop triggering and must be updated.
+
+    | Role        | Old                       | New                                  |
+    | ----------- | ------------------------- | ------------------------------------ |
+    | `alloy`     | `reload systemd`          | `alloy: reload systemd`              |
+    | `alloy`     | `restart alloy`           | `alloy: restart alloy`               |
+    | `alloy`     | `restart grafana alloy`   | `alloy: restart grafana alloy`       |
+    | `alloy`     | `update apt cache`        | `alloy: update apt cache`            |
+    | `do`        | `reload systemd`          | `do: reload systemd`                 |
+    | `do`        | `restart do agent`        | `do: restart do agent`               |
+    | `tailscale` | `reload systemd`          | `tailscale: reload systemd`          |
+    | `tailscale` | `restart tailscaled`      | `tailscale: restart tailscaled`      |
+    | `tailscale` | `reload tailscale config` | `tailscale: reload tailscale config` |
+    | `tailscale` | `refresh ansible facts`   | `tailscale: refresh ansible facts`   |
+
+    Handler names stay descriptive sentences; only the `listen:` topics carry
+    the prefix, matching the convention in `arillso/ansible.system`. This also
+    resolves a case mismatch in the `tailscale` role, where one task notified
+    the handler by name (`Refresh ansible facts`) while every other call site
+    used the lowercase listen topic.
+
 - **BREAKING — boolean variable naming (`alloy`, `do`)**: 13 boolean variables
   moved from the `*_enable_*` prefix form to the `*_enabled` suffix form. The
   old names are gone; there is no deprecation alias, so playbooks setting them

--- a/roles/alloy/handlers/main.yml
+++ b/roles/alloy/handlers/main.yml
@@ -1,24 +1,24 @@
 ---
 # Handler definitions for Grafana Alloy role
 
-- name: Reload systemd
+- name: Reload systemd to pick up Grafana Alloy unit changes
   ansible.builtin.systemd_service:
       daemon_reload: true
   become: true
-  listen: reload systemd
+  listen: "alloy: reload systemd"
 
-- name: Restart alloy
+- name: Restart Grafana Alloy to apply configuration changes
   ansible.builtin.systemd_service:
       name: "{{ alloy_service_name }}"
       state: restarted
   become: true
   listen:
-      - restart alloy
-      - restart grafana alloy
+      - "alloy: restart alloy"
+      - "alloy: restart grafana alloy"
 
-- name: Update apt cache
+- name: Update apt cache before installing Grafana Alloy packages
   ansible.builtin.apt:
       update_cache: true
   become: true
-  listen: update apt cache
+  listen: "alloy: update apt cache"
   when: ansible_os_family == "Debian"

--- a/roles/alloy/tasks/configure.yml
+++ b/roles/alloy/tasks/configure.yml
@@ -10,7 +10,7 @@
       mode: "0644"
       backup: true
   become: true
-  notify: restart alloy
+  notify: "alloy: restart alloy"
 
 - name: Create systemd service override directory
   ansible.builtin.file:
@@ -30,8 +30,8 @@
       mode: "0644"
   become: true
   notify:
-      - reload systemd
-      - restart alloy
+      - "alloy: reload systemd"
+      - "alloy: restart alloy"
 
 - name: Create environment file
   ansible.builtin.template:
@@ -41,7 +41,7 @@
       group: root
       mode: "0600"
   become: true
-  notify: restart alloy
+  notify: "alloy: restart alloy"
   no_log: "{{ alloy_no_log_env_file | default(true) }}"
 
 - name: Ensure log directory exists with proper permissions

--- a/roles/alloy/tasks/install.yml
+++ b/roles/alloy/tasks/install.yml
@@ -102,7 +102,7 @@
   when:
       - ansible_os_family == "RedHat"
       - not alloy_package_only
-  notify: restart alloy
+  notify: "alloy: restart alloy"
   tags: [alloy, install, package]
 
 # Package-only installation (Alpine, Arch, etc.)
@@ -115,7 +115,7 @@
   delay: 10
   until: _alloy_package_installed_simple is succeeded
   when: alloy_package_only
-  notify: restart alloy
+  notify: "alloy: restart alloy"
   tags: [alloy, install, package]
 
 # Generic installation for other OS families (fallback)
@@ -130,7 +130,7 @@
   when:
       - ansible_os_family not in ["Debian", "RedHat"]
       - not alloy_package_only
-  notify: restart alloy
+  notify: "alloy: restart alloy"
   tags: [alloy, install, package]
 
 - name: Create required directories

--- a/roles/alloy/tasks/service.yml
+++ b/roles/alloy/tasks/service.yml
@@ -4,7 +4,7 @@
 
 - name: "Enable and start Grafana Alloy service"
   # No daemon_reload here: it always reports changed and breaks
-  # idempotence. The `reload systemd` handler (notified by the service
+  # idempotence. The `alloy: reload systemd` handler (notified by the service
   # override) covers unit-file reloads.
   ansible.builtin.systemd_service:
       name: "{{ alloy_service_name }}"

--- a/roles/alloy/tasks/textfile.yml
+++ b/roles/alloy/tasks/textfile.yml
@@ -53,7 +53,7 @@
   loop_control:
       label: "{{ item.name }}"
   register: _alloy_textfile_service_units
-  notify: reload systemd
+  notify: "alloy: reload systemd"
 
 - name: Deploy textfile collector systemd .timer units
   ansible.builtin.template:
@@ -67,7 +67,7 @@
   loop_control:
       label: "{{ item.name }}"
   register: _alloy_textfile_timer_units
-  notify: reload systemd
+  notify: "alloy: reload systemd"
 
 - name: Apply pending systemd daemon-reload before timer enable
   ansible.builtin.meta: flush_handlers

--- a/roles/do/handlers/main.yml
+++ b/roles/do/handlers/main.yml
@@ -1,15 +1,15 @@
 ---
 # Handler definitions for DigitalOcean Agent role
 
-- name: Reload systemd
+- name: Reload systemd to pick up DigitalOcean agent unit changes
   ansible.builtin.systemd_service:
       daemon_reload: true
   become: true
-  listen: reload systemd
+  listen: "do: reload systemd"
 
-- name: Restart do agent
+- name: Restart DigitalOcean agent to apply configuration changes
   ansible.builtin.systemd_service:
       name: do-agent
       state: restarted
   become: true
-  listen: restart do agent
+  listen: "do: restart do agent"

--- a/roles/do/tasks/configure.yml
+++ b/roles/do/tasks/configure.yml
@@ -18,7 +18,7 @@
       group: root
       mode: "0600"
   become: true
-  notify: restart do agent
+  notify: "do: restart do agent"
   no_log: "{{ do_no_log_api_token | default(true) }}"
   when: do_custom_config_enabled | default(false)
 
@@ -30,6 +30,6 @@
       group: root
       mode: "0600"
   become: true
-  notify: restart do agent
+  notify: "do: restart do agent"
   no_log: "{{ do_no_log_api_token | default(true) }}"
   when: do_api_token != "" or do_custom_config_enabled | default(false)

--- a/roles/do/tasks/install.yml
+++ b/roles/do/tasks/install.yml
@@ -40,7 +40,7 @@
       name: "{{ do_package_name }}"
       state: present
   become: true
-  notify: restart do agent
+  notify: "do: restart do agent"
 
 - name: Create required directories
   ansible.builtin.file:

--- a/roles/tailscale/handlers/main.yml
+++ b/roles/tailscale/handlers/main.yml
@@ -2,28 +2,28 @@
 # Tailscale Service Handlers
 # Handlers for Tailscale service restarts and systemd reload
 
-- name: Reload systemd
+- name: Reload systemd to pick up Tailscale unit changes
   ansible.builtin.systemd_service:
       daemon_reload: true
   become: true
-  listen: reload systemd
+  listen: "tailscale: reload systemd"
 
-- name: Restart tailscaled
+- name: Restart tailscaled to apply service changes
   ansible.builtin.systemd_service:
       name: tailscaled
       state: restarted
       daemon_reload: true
   become: true
-  listen: restart tailscaled
+  listen: "tailscale: restart tailscaled"
 
-- name: Reload tailscale config
+- name: Reload Tailscale configuration without restarting the daemon
   ansible.builtin.command:
       cmd: tailscale debug reload-config
   become: true
-  listen: reload tailscale config
+  listen: "tailscale: reload tailscale config"
   changed_when: true
 
-- name: Refresh ansible facts
+- name: Refresh Ansible facts after updating local fact scripts
   ansible.builtin.setup:
       filter: ansible_local
-  listen: refresh ansible facts
+  listen: "tailscale: refresh ansible facts"

--- a/roles/tailscale/tasks/configure.yml
+++ b/roles/tailscale/tasks/configure.yml
@@ -57,7 +57,7 @@
   when:
       - tailscale_config_enabled | default(true) | bool
       - _tailscale_has_config | bool
-  notify: reload tailscale config
+  notify: "tailscale: reload tailscale config"
   tags: [tailscale, config, daemon]
 
 - name: Create Tailscale systemd override directory
@@ -85,8 +85,8 @@
       (tailscale_config_enabled | default(true) | bool and _tailscale_has_config | bool) or
       (tailscale_service_override | length > 0)
   notify:
-      - reload systemd
-      - restart tailscaled
+      - "tailscale: reload systemd"
+      - "tailscale: restart tailscaled"
   tags: [tailscale, config, daemon, systemd]
 
 - name: Initial authentication with auth key
@@ -101,7 +101,7 @@
   when:
       - tailscale_auth_key | length > 0
       - not ansible_local.tailscale.authenticated | default(false)
-  notify: restart tailscaled
+  notify: "tailscale: restart tailscaled"
   no_log: "{{ tailscale_no_log_auth_key | default(true) }}"
   tags: [tailscale, config, auth]
 

--- a/roles/tailscale/tasks/facts.yml
+++ b/roles/tailscale/tasks/facts.yml
@@ -20,7 +20,7 @@
       owner: root
       group: root
   become: true
-  notify: Refresh ansible facts
+  notify: "tailscale: refresh ansible facts"
   tags: [tailscale, facts]
 
 - name: Flush handlers to refresh facts immediately


### PR DESCRIPTION
## Summary

- The alloy, do and tailscale roles each defined a handler listening on the bare topic `reload systemd`. Loading all three in one play made a single notify fire the handlers of all three roles.
- Handler listen topics are now prefixed with their role (`alloy: reload systemd`, `do: restart do agent`, …), following the convention already used in `arillso/ansible.system`. Handler names stay descriptive so `name[casing]` keeps passing under the production profile.
- All `notify:` values inside the roles were updated to the prefixed topics. This also resolves a case mismatch where `roles/tailscale/tasks/facts.yml` notified `Refresh ansible facts` by handler name while every other call site used the lowercase listen topic.

## Test plan

- [ ] `ansible-lint --profile=production` passes in CI (not runnable in the build environment — no ansible-lint binary available)
- [ ] `yamllint -c .yamllint roles/` passes — verified locally
- [ ] `prettier --check` on all changed files passes — verified locally
- [ ] Every `notify:` in the three roles resolves to a `listen:` topic of the same role, verified by parsing the handler and task files