### PR TITLE
refactor(repo): rename yamllint config and raise line-length to 500

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,7 +3,7 @@ extends: default
 
 rules:
     line-length:
-        max: 160
+        max: 500
         level: warning
 
     comments:
@@ -17,7 +17,7 @@ rules:
         check-multi-line-strings: false
 
     truthy:
-        allowed-values: ['true', 'false']
+        allowed-values: ["true", "false"]
         check-keys: false
 
     brackets:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git checkout -b fix/issue-description
 - Use 4 spaces for indentation (no tabs)
 - Use lowercase with underscores for variable names
 - Prefix role variables with the role name
-- Keep lines under 160 characters
+- Keep lines under 500 characters
 - Require `---` document start
 
 ### Python
@@ -61,7 +61,7 @@ git checkout -b fix/issue-description
 
 ### Role Structure
 
-```
+```text
 roles/ROLE_NAME/
 ├── defaults/
 │   └── main.yml              # User-configurable variables
@@ -116,7 +116,7 @@ make build
 
 Write clear, descriptive commit messages:
 
-```
+```text
 Brief summary (50 chars or less)
 
 - Detailed description with bullet points

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,7 +21,7 @@ pre-commit:
         yamllint:
             glob: "*.{yml,yaml}"
             exclude: "(^\\.ansible/)"
-            run: yamllint -c .yamllint {staged_files}
+            run: yamllint -c .yamllint.yml {staged_files}
         markdownlint:
             glob: "*.md"
             exclude: "(^\\.ansible/)"


### PR DESCRIPTION
## Summary

- Rename `.yamllint` to `.yamllint.yml` so the published CI template, which hardcodes `config_file: .yamllint.yml`, finds this repo's config. Copying that template previously produced a workflow that silently missed the config.
- Raise `line-length.max` from 160 to 500 (still `level: warning`); `CONTRIBUTING.md` documented the old 160-character limit and now matches.
- Pull the explicit reference in `lefthook.yml` (`yamllint -c .yamllint`) along with the rename. The `Makefile` needs no change: `yamllint .` relies on auto-discovery, which finds the new name too.
- The 16-rule body is otherwise unchanged.

Two incidental fixes the rename forced, both pre-existing on `main`:

- `.yamllint.yml` now uses double quotes in `truthy.allowed-values`. The old extensionless name fell outside the `*.{yml,yaml}` prettier glob, so the file was never checked; the rename brings it in scope and prettier gated the commit.
- Two unlabelled fenced code blocks in `CONTRIBUTING.md` (a directory tree and a commit-message example) are now tagged `text`. markdownlint MD040 fails on them on `main` as well and blocks any commit touching that file.

Remaining `.yamllint` mentions in `CHANGELOG.md` are historical release entries and were deliberately left as-is.

## Test plan

- [x] `yamllint -c .yamllint.yml .` passes
- [x] `yamllint .` passes via auto-discovery (the `make lint-yaml` path)
- [x] `pytest tests/unit/` passes (9 tests)
- [x] lefthook pre-commit green: gitleaks, yamllint, prettier, markdownlint
- [ ] CI green