### PR TITLE
fix(license): capitalize Arillso in copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2026 arillso
+Copyright (c) 2022-2026 Arillso
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Align the LICENSE copyright line with the canonical format used across the arillso repos: `Arillso` instead of lowercase `arillso`.
- Year range `2022-2026` stays unchanged; this is the only deviation this repo had.

## Test plan

- [ ] CI green
- [ ] `LICENSE` line 3 reads `Copyright (c) 2022-2026 Arillso`, matching the `## Copyright` section in `README.md`