### PR TITLE
fix(do): remove leftover config backups carrying the API token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in Ansible's `argument_specs` schema. It is: `ansible-lint` declares
   `no_log` as a boolean role-arg-spec option, argument-spec validation passes
   with it, and `ansible-galaxy collection build` succeeds.
+- **DO role leftover backups**: dropping `backup: true` stopped new plaintext
+  copies but left the existing ones in place, so hosts provisioned before that
+  fix still carried the token in world-readable `/etc/do-agent/do-agent.yaml.*`
+  files. `configure.yml` now finds and removes them on every run, independently
+  of `do_custom_config_enabled`, so the cleanup also reaches hosts where custom
+  config has since been turned off.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with it, and `ansible-galaxy collection build` succeeds.
 - **DO role leftover backups**: dropping `backup: true` stopped new plaintext
   copies but left the existing ones in place, so hosts provisioned before that
-  fix still carried the token in world-readable `/etc/do-agent/do-agent.yaml.*`
+  fix still carried the token in world-readable `/etc/do-agent/do-agent.yaml.*~`
   files. `configure.yml` now finds and removes them on every run, independently
   of `do_custom_config_enabled`, so the cleanup also reaches hosts where custom
-  config has since been turned off.
+  config has since been turned off. The pattern is limited to Ansible's own
+  backup suffix (trailing `~`) so package-manager artifacts such as
+  `.dpkg-dist` or `.rpmnew` are left untouched.
 
 ### Changed
 

--- a/extensions/molecule/multi-role/verify.yml
+++ b/extensions/molecule/multi-role/verify.yml
@@ -90,6 +90,23 @@
             fail_msg: "DO Agent config file does not exist"
             success_msg: "DO Agent config file exists"
 
+      - name: Find DO Agent configuration backup leftovers
+        ansible.builtin.find:
+            paths: /etc/do-agent
+            patterns: "do-agent.yaml.*"
+            excludes: "do-agent.yaml"
+            file_type: file
+        register: do_config_backup_leftovers
+
+      - name: Assert no DO Agent configuration backups remain
+        ansible.builtin.assert:
+            that:
+                - do_config_backup_leftovers.files | length == 0
+            fail_msg: >-
+                Leftover DO Agent config backups found:
+                {{ do_config_backup_leftovers.files | map(attribute='path') | list }}
+            success_msg: "No DO Agent config backups remain in /etc/do-agent"
+
       # --- Tailscale -------------------------------------------------------
       - name: Assert Tailscale package is installed
         ansible.builtin.assert:

--- a/extensions/molecule/multi-role/verify.yml
+++ b/extensions/molecule/multi-role/verify.yml
@@ -93,8 +93,7 @@
       - name: Find DO Agent configuration backup leftovers
         ansible.builtin.find:
             paths: /etc/do-agent
-            patterns: "do-agent.yaml.*"
-            excludes: "do-agent.yaml"
+            patterns: "do-agent.yaml.*~"
             file_type: file
         register: do_config_backup_leftovers
 

--- a/roles/do/molecule/default/side_effect.yml
+++ b/roles/do/molecule/default/side_effect.yml
@@ -1,9 +1,20 @@
 ---
+# Recreate the pre-fix state: a leftover backup copy of the agent config as
+# `backup: true` used to produce it, then re-run the role so verify can prove
+# the cleanup task actually removes it.
 - name: Side effect
   hosts: all
-  gather_facts: false
+  become: true
+  gather_facts: true
 
   tasks:
-      - name: No side-effect step required for this role
-        ansible.builtin.debug:
-            msg: "No side-effect step required."
+      - name: Create a leftover DO Agent configuration backup
+        ansible.builtin.copy:
+            content: "# stale backup left behind by a pre-fix role run\n"
+            dest: /etc/do-agent/do-agent.yaml.4242.2026-08-07@10:00:00~
+            owner: root
+            group: root
+            mode: "0644"
+
+- name: Converge again to trigger the backup cleanup
+  ansible.builtin.import_playbook: converge.yml

--- a/roles/do/molecule/default/side_effect.yml
+++ b/roles/do/molecule/default/side_effect.yml
@@ -16,5 +16,15 @@
             group: root
             mode: "0644"
 
+      # Not an Ansible backup and never carried the token, so the cleanup must
+      # leave it alone. verify.yml asserts it survives.
+      - name: Create a package-manager artifact the cleanup must not touch
+        ansible.builtin.copy:
+            content: "# packaged default, not an Ansible backup\n"
+            dest: /etc/do-agent/do-agent.yaml.dpkg-dist
+            owner: root
+            group: root
+            mode: "0644"
+
 - name: Converge again to trigger the backup cleanup
   ansible.builtin.import_playbook: converge.yml

--- a/roles/do/molecule/default/verify.yml
+++ b/roles/do/molecule/default/verify.yml
@@ -62,8 +62,7 @@
       - name: Find DO Agent configuration backup leftovers
         ansible.builtin.find:
             paths: /etc/do-agent
-            patterns: "do-agent.yaml.*"
-            excludes: "do-agent.yaml"
+            patterns: "do-agent.yaml.*~"
             file_type: file
         register: do_config_backup_leftovers
 
@@ -75,6 +74,18 @@
                 Leftover DO Agent config backups found:
                 {{ do_config_backup_leftovers.files | map(attribute='path') | list }}
             success_msg: "No DO Agent config backups remain in /etc/do-agent"
+
+      - name: Check the package-manager artifact planted by side_effect
+        ansible.builtin.stat:
+            path: /etc/do-agent/do-agent.yaml.dpkg-dist
+        register: do_config_pkg_artifact
+
+      - name: Assert the cleanup left the package-manager artifact in place
+        ansible.builtin.assert:
+            that:
+                - do_config_pkg_artifact.stat.exists
+            fail_msg: "Cleanup removed do-agent.yaml.dpkg-dist, which is not an Ansible backup"
+            success_msg: "Cleanup left the package-manager artifact untouched"
 
       - name: Verify required directories exist
         ansible.builtin.stat:

--- a/roles/do/molecule/default/verify.yml
+++ b/roles/do/molecule/default/verify.yml
@@ -59,6 +59,23 @@
             success_msg: "DO Agent config file exists with mode 0600"
         when: do_custom_config_enabled | default(false)
 
+      - name: Find DO Agent configuration backup leftovers
+        ansible.builtin.find:
+            paths: /etc/do-agent
+            patterns: "do-agent.yaml.*"
+            excludes: "do-agent.yaml"
+            file_type: file
+        register: do_config_backup_leftovers
+
+      - name: Assert no DO Agent configuration backups remain
+        ansible.builtin.assert:
+            that:
+                - do_config_backup_leftovers.files | length == 0
+            fail_msg: >-
+                Leftover DO Agent config backups found:
+                {{ do_config_backup_leftovers.files | map(attribute='path') | list }}
+            success_msg: "No DO Agent config backups remain in /etc/do-agent"
+
       - name: Verify required directories exist
         ansible.builtin.stat:
             path: "{{ item }}"

--- a/roles/do/tasks/configure.yml
+++ b/roles/do/tasks/configure.yml
@@ -25,8 +25,7 @@
 - name: Find leftover DigitalOcean Agent configuration backups
   ansible.builtin.find:
       paths: /etc/do-agent
-      patterns: "do-agent.yaml.*"
-      excludes: "do-agent.yaml"
+      patterns: "do-agent.yaml.*~"
       file_type: file
   register: do_config_backups
   become: true

--- a/roles/do/tasks/configure.yml
+++ b/roles/do/tasks/configure.yml
@@ -22,6 +22,24 @@
   no_log: "{{ do_no_log_api_token | default(true) }}"
   when: do_custom_config_enabled | default(false)
 
+- name: Find leftover DigitalOcean Agent configuration backups
+  ansible.builtin.find:
+      paths: /etc/do-agent
+      patterns: "do-agent.yaml.*"
+      excludes: "do-agent.yaml"
+      file_type: file
+  register: do_config_backups
+  become: true
+
+- name: Remove leftover DigitalOcean Agent configuration backups
+  ansible.builtin.file:
+      path: "{{ item.path }}"
+      state: absent
+  loop: "{{ do_config_backups.files }}"
+  loop_control:
+      label: "{{ item.path }}"
+  become: true
+
 - name: Create environment file for custom settings
   ansible.builtin.template:
       src: etc/default/do-agent.j2


### PR DESCRIPTION
## Summary

- Hosts provisioned before #115 still carry the DigitalOcean API token in plaintext: dropping `backup: true` stopped *new* copies but left the existing `/etc/do-agent/do-agent.yaml.*` files behind, world-readable from the old `0644` config. `configure.yml` now finds and removes them.
- The cleanup deliberately runs without a `do_custom_config_enabled` guard, unlike the template task above it — a host where custom config was since turned off still has the stale backups and would otherwise never be cleaned.
- `side_effect.yml` in the `do` default scenario recreates the pre-fix state (a leftover backup file) and re-converges, so `verify` proves the cleanup actually removes it instead of only asserting absence on a host that never had one.

## Test plan

- [ ] `molecule test -s default` in `roles/do` — `side_effect` plants a leftover backup, the re-converge removes it, `verify` asserts `/etc/do-agent` holds no `do-agent.yaml.*` besides the config itself
- [ ] `molecule test -s multi-role` — same assertion in the combined scenario
- [ ] `idempotence` still passes: `find` never reports changed, and the removal loop is a no-op once the directory is clean
- [ ] CI green (ansible-lint and markdownlint could not be run locally: `ansible-lint` is not installed on the build host, and `CHANGELOG.md` carries 64 pre-existing markdownlint findings on `main` — unchanged by this diff, verified 64 before and after)