### PR TITLE
fix(do): remove three inert feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **DO**: the three feature flags `do_metrics_enabled`, `do_logs_enabled` and
+  `do_insights_enabled` are gone from `defaults/main.yml` and
+  `meta/argument_specs.yml`. They were declared and documented but read by no
+  task and no template, so setting one to `false` changed nothing and raised no
+  error. `do-agent` has no upstream switch for metrics, logs or insights as a
+  whole — only per-collector flags such as `no-collector.processes` — so there
+  is nothing to wire them to. Removing them has no effect on behaviour. The
+  master switch `do_enabled` is unaffected and still gates the whole role.
 - **Alloy (breaking)**: the six unprefixed Grafana Cloud variables the role read
   are replaced by role-prefixed names. They were never declared in
   `defaults/main.yml` or `meta/argument_specs.yml` and worked only through
@@ -129,7 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the handler by name (`Refresh ansible facts`) while every other call site
     used the lowercase listen topic.
 
-- **BREAKING — boolean variable naming (`alloy`, `do`)**: 13 boolean variables
+- **BREAKING — boolean variable naming (`alloy`)**: 10 boolean variables
   moved from the `*_enable_*` prefix form to the `*_enabled` suffix form. The
   old names are gone; there is no deprecation alias, so playbooks setting them
   silently lose the setting and must be updated. This also fixes the `alloy`
@@ -148,9 +156,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     | `alloy` | `alloy_enable_advanced_node_exporter` | `alloy_advanced_node_exporter_enabled` |
     | `alloy` | `alloy_enable_journal_monitoring`     | `alloy_journal_monitoring_enabled`     |
     | `alloy` | `alloy_enable_remotecfg`              | `alloy_remotecfg_enabled`              |
-    | `do`    | `do_enable_metrics`                   | `do_metrics_enabled`                   |
-    | `do`    | `do_enable_logs`                      | `do_logs_enabled`                      |
-    | `do`    | `do_enable_insights`                  | `do_insights_enabled`                  |
 
     The `enable_start_time_metrics`, `enable_task_metrics` and
     `enable_restarts_metrics` keys inside `alloy_node_exporter_config.systemd`

--- a/roles/do/defaults/main.yml
+++ b/roles/do/defaults/main.yml
@@ -18,11 +18,6 @@ do_storage_path: "/var/lib/do-agent"
 # Custom configuration (usually not required)
 do_custom_config_enabled: false
 
-# Feature flags
-do_metrics_enabled: true
-do_logs_enabled: true
-do_insights_enabled: true
-
 # Optional API configuration
 do_api_token: ""
 do_droplet_id: ""

--- a/roles/do/meta/argument_specs.yml
+++ b/roles/do/meta/argument_specs.yml
@@ -94,24 +94,6 @@ argument_specs:
                     no_log toggle for the token-rendering tasks; set false to
                     surface a template error hidden as 'non-zero return code'.
 
-            do_metrics_enabled:
-                type: "bool"
-                required: false
-                default: true
-                description: "Enables metrics collection"
-
-            do_logs_enabled:
-                type: "bool"
-                required: false
-                default: true
-                description: "Enables log collection"
-
-            do_insights_enabled:
-                type: "bool"
-                required: false
-                default: true
-                description: "Enables DigitalOcean Insights"
-
             do_prometheus_enabled:
                 type: "bool"
                 required: false


### PR DESCRIPTION
## Summary

- Remove `do_metrics_enabled`, `do_logs_enabled` and `do_insights_enabled` from `roles/do/defaults/main.yml` and `roles/do/meta/argument_specs.yml`. They were declared and documented but read by no task and no template, so setting one to `false` changed nothing and raised no error.
- `do-agent` exposes no upstream switch for metrics, logs or insights as a whole — only per-collector flags such as `no-collector.processes` — so there is nothing to wire them to. Removing them is behaviour-neutral.
- Correct the `Unreleased` rename table, which still listed the three flags as rename targets that no longer exist after this removal, and adjust the entry's count and role scope accordingly. The `1.2.0` entry is left untouched as a historical record.

## Test plan

- [ ] `yamllint roles/do` clean
- [ ] `defaults/main.yml` and `meta/argument_specs.yml` stay in 1:1 correspondence (17 keys each, no drift in either direction)
- [ ] Role runs with argument-spec validation passing, and `do_enabled=false` still skips the whole role
- [ ] CI green, including `ansible-lint` and the `molecule-do` `default` and `disabled` scenarios