### PR TITLE
ci: run the unit test job on pull requests and merges

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,6 +25,7 @@ jobs:
             collection_namespace: arillso
             collection_name: agent
             python_version: "3.13"
+            enable_unit_tests: true
 
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-07

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,6 +27,7 @@ jobs:
             collection_namespace: arillso
             collection_name: agent
             python_version: "3.13"
+            enable_unit_tests: true
 
     molecule-alloy:
         # alloy must run as a stable systemd service, which is unreliable


### PR DESCRIPTION
## Summary

- The reusable `ci-ansible-collection.yml` gates its `Unit Tests` job behind `enable_unit_tests`, which defaults to `false`. Neither `pull-request.yml` nor `merge.yml` passed the input, so the job reported `skipped` and the tests under `tests/unit/` never ran.
- Both callers now pass `enable_unit_tests: true`, so a regression in the unit tests fails the pull request and the merge run instead of going unnoticed.
- Integration tests stay disabled: `tests/integration/` does not exist in this collection, so enabling `enable_integration_tests` would only add a job with nothing to run.

## Test plan

- [ ] `Unit Tests` shows up as an executed job on this pull request instead of `skipped`
- [ ] The unit test job passes (9 tests in `tests/unit/test_alloy_env_template.py`)
- [ ] CI green, `actionlint`/`yamllint`/`prettier` clean