### PR TITLE
chore(deps): update arillso/.github to 2026-08-09

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>arillso/.github:renovate-ansible#2026-08-07"],
+    "extends": ["github>arillso/.github:renovate-ansible#2026-08-09"],
     "packageRules": [
         {
             "matchPackageNames": ["ansible-core"],

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
     ci:
-        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-09
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -28,4 +28,4 @@ jobs:
             enable_unit_tests: true
 
     security-secrets:
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-09

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
     security-secrets:
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-09

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
     ci:
-        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-09
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -36,7 +36,7 @@ jobs:
         # scenarios_root is set per role and the matrix is pinned to the
         # single `default` scenario. concurrency-suffix keeps this nested
         # call out of the caller's concurrency group.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-09
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -49,7 +49,7 @@ jobs:
     molecule-do:
         # do and tailscale converge fine under the docker driver (their
         # molecule.yml uses driver: docker), so keep the default driver.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-09
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -60,7 +60,7 @@ jobs:
             concurrency-suffix: molecule-do
 
     molecule-tailscale:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-09
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -74,7 +74,7 @@ jobs:
         # Combined scenario deploying alloy, do and tailscale on one host
         # (extensions/molecule/multi-role). Docker driver like the do/tailscale
         # default scenarios.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-09
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -85,9 +85,9 @@ jobs:
             concurrency-suffix: molecule-multi-role
 
     security-secrets:
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-09
 
     claude-review:
-        uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-08-09
         secrets:
             CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
     publish:
-        uses: arillso/.github/.github/workflows/release-ansible-collection.yml@2026-08-07
+        uses: arillso/.github/.github/workflows/release-ansible-collection.yml@2026-08-09
         with:
             collection_namespace: arillso
             collection_name: agent


### PR DESCRIPTION
## Summary

- Move all eleven `arillso/.github` reusable workflow pins and the `renovate-ansible` preset reference from `2026-08-07` to `2026-08-09`.
- The reason to do this now rather than wait for Renovate is the TruffleHog `lob` detector exclusion in arillso/.github#97. Without it the secret scan fails on this repository: the detector matches `(live|test)_[a-zA-Z0-9_]{35}` with no entropy requirement and counts the 422 from its empty-body probe as verification, so the two 40-character pytest function names in `tests/unit/test_argument_spec_no_log.py` are reported as verified credentials. `main` has been red since `da395bb`, and #124 is blocked behind the same finding.
- No reusable this repository calls changed its input signature between the two tags, so the bump is not breaking for the caller. The other changes it picks up are the caller-input-injection hardening, the molecule failure-text surfacing, and the tag-version interpolation fix.

## Test plan

- [ ] CI green on this PR, including the secret scan that is currently failing on `main`
- [ ] `security-secrets / Scan with TruffleHog` reports no findings
- [ ] Gitleaks and pattern detection still run and still pass
- [ ] Molecule scenarios for all three roles and the multi-role scenario stay green