### PR TITLE
refactor(makefile): split test target into test-unit and test-molecule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,18 @@ This runs ansible-lint, yamllint, and Python linters (ruff, black).
 ### Unit Tests
 
 ```bash
-make test
+make test-unit
 ```
+
+### Molecule Tests
+
+```bash
+make test-molecule
+```
+
+This runs every molecule scenario serially and stops at the first failure.
+The alloy scenarios use the qemu driver, so they need KVM and your user in the
+`kvm` group.
 
 ### Auto-format
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: help lint lint-ansible lint-yaml lint-python format test-unit test-molecule build clean install-dev
 
+MOLECULE_SCENARIOS := $(sort $(wildcard roles/*/molecule/*/molecule.yml) \
+                            $(wildcard extensions/molecule/*/molecule.yml))
+
 help: ## Show this help message
 	@echo 'Usage: make [target]'
 	@echo ''
@@ -43,6 +46,16 @@ test-unit: ## Run unit tests
 	else \
 		echo "No unit tests found, skipping..."; \
 	fi
+
+test-molecule: ## Run all molecule scenarios
+	@if [ -z "$(MOLECULE_SCENARIOS)" ]; then \
+		echo "No molecule scenarios found, skipping..."; \
+	fi
+	@for cfg in $(MOLECULE_SCENARIOS); do \
+		dir=$${cfg%/molecule.yml}; scenario=$${dir##*/}; base=$${dir%/molecule/*}; \
+		echo "Running molecule scenario $$scenario in $$base..."; \
+		( cd "$$base" && molecule test -s "$$scenario" ) || exit 1; \
+	done
 
 build: ## Build collection
 	@echo "Building collection..."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint lint-ansible lint-yaml lint-python format test build clean install-dev
+.PHONY: help lint lint-ansible lint-yaml lint-python format test-unit test-molecule build clean install-dev
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -36,9 +36,13 @@ format: ## Auto-format Python code
 		echo "No Python plugins found, skipping..."; \
 	fi
 
-test: ## Run tests
-	@echo "Running pytest..."
-	@pytest tests/unit/
+test-unit: ## Run unit tests
+	@if [ -d tests/unit ]; then \
+		echo "Running pytest..."; \
+		pytest tests/unit/; \
+	else \
+		echo "No unit tests found, skipping..."; \
+	fi
 
 build: ## Build collection
 	@echo "Building collection..."


### PR DESCRIPTION
## Summary

- Rename the `test` target to `test-unit` and guard it on `tests/unit/` existing, matching the pattern already used by `lint-python` for `plugins/`.
- Add a `test-molecule` target that discovers scenarios via `wildcard` and runs them serially, stopping at the first failure. Discovery finds all seven scenarios (`roles/{alloy,do,tailscale}/molecule/{default,disabled}` and `extensions/molecule/multi-role`), so a new role needs no second place to update.
- No `test` alias remains; running both suites is `make test-unit test-molecule`.
- Each scenario keeps the driver from its own `molecule.yml` — no driver override, since the alloy scenarios need qemu rather than docker.

## Test plan

- [x] `make test-unit` runs the suite (19 tests pass)
- [x] Guard branch: with `tests/unit/` absent, `make test-unit` prints the skip message and exits 0
- [x] `make test` now fails with `No rule to make target 'test'` (intentional, no alias)
- [x] `make -n test-molecule` resolves all seven scenarios, none duplicated
- [x] Scenario/base pair resolution verified: every `$base/molecule/$scenario/molecule.yml` exists
- [x] `make help` lists both `test-unit` and `test-molecule`
- [x] `yamllint` clean
- [ ] `make test-molecule` not executed locally (molecule not installed on this host); CI covers the scenarios via `pull-request.yml`