### PR TITLE
ci(lint): enforce var-naming[no-role-prefix] and production profile

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,9 +5,11 @@ exclude_paths:
     - .venv/
     - venv/
 
+profile: production
+strict: true
+
 skip_list:
     - galaxy[version-incorrect]
-    - var-naming[no-role-prefix]
     - command-instead-of-module
     - no-handler
     - package-latest

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,8 +14,4 @@ skip_list:
     - no-handler
     - package-latest
 
-warn_list:
-    - name[casing]
-    - yaml[line-length]
-
 use_default_rules: true


### PR DESCRIPTION
## Summary

- Remove `var-naming[no-role-prefix]` from the `skip_list` and add `profile: production` plus `strict: true` to `.ansible-lint`.
- The repository already satisfies the rule, so this locks in the current state rather than fixing a defect. All role registers pass because the rule strips a leading underscore before comparing the prefix, and molecule `verify.yml` registers sit at play level where the sub-rule cannot apply.
- No register renames were needed; the change is limited to the lint configuration.

## Test plan

- [x] Baseline run before the change: `0 failure(s), 0 warning(s) on 121 files`
- [x] Positive control: an invalid register name triggers `var-naming[pattern]`
- [x] Positive control: an unprefixed register in a role triggers `var-naming[no-role-prefix]` once the skip entry is removed, and passes silently while it is present
- [x] Run with the target config: `Passed: 0 failure(s), 0 warning(s) on 121 files. Profile 'production' was required, and it passed.`
- [x] `yamllint` clean on the changed file
- [ ] CI green