### PR TITLE
refactor: read facts from ansible_facts instead of top-level vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `key_pem`, `server_name`, and `min_version` options the template already
   renders.
 
+### Changed
+
+- **All roles**: every top-level fact reference is replaced by its
+  `ansible_facts` equivalent — `ansible_os_family` becomes
+  `ansible_facts['os_family']`, `ansible_hostname` becomes
+  `ansible_facts['hostname']`, and the `ansible_distribution*` family becomes
+  `ansible_facts['distribution*']`. `ansible-core` deprecated the
+  `INJECT_FACTS_AS_VARS` default of `True` and drops the automatic top-level
+  injection in version 2.24, which would leave the unprefixed names undefined
+  and break the roles. Variable names only, no behaviour change.
+  `ansible_local` keeps its name: it is exempt from the deprecation and stays
+  at the top level even when read from `ansible_facts`.
+
 ### Removed
 
 - **DO**: the three feature flags `do_metrics_enabled`, `do_logs_enabled` and

--- a/extensions/molecule/multi-role/prepare.yml
+++ b/extensions/molecule/multi-role/prepare.yml
@@ -10,4 +10,4 @@
         ansible.builtin.apt:
             update_cache: true
             cache_valid_time: 3600
-        when: ansible_os_family == "Debian"
+        when: ansible_facts['os_family'] == "Debian"

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -7,10 +7,10 @@ alloy_enabled: true
 
 # OS-specific variable mappings - these map internal vars to public API
 # Dynamic variable assignment based on OS family using hierarchical structure
-alloy_package_dependencies: "{{ _alloy_os[ansible_os_family].package_dependencies }}"
-alloy_grafana_gpg_key_url: "{{ _alloy_os[ansible_os_family].grafana.gpg_key_url }}"
-alloy_grafana_keyring_path: "{{ _alloy_os[ansible_os_family].grafana.keyring_path | default(omit) }}"
-alloy_grafana_repository: "{{ _alloy_os[ansible_os_family].grafana.repository | default(omit) }}"
+alloy_package_dependencies: "{{ _alloy_os[ansible_facts['os_family']].package_dependencies }}"
+alloy_grafana_gpg_key_url: "{{ _alloy_os[ansible_facts['os_family']].grafana.gpg_key_url }}"
+alloy_grafana_keyring_path: "{{ _alloy_os[ansible_facts['os_family']].grafana.keyring_path | default(omit) }}"
+alloy_grafana_repository: "{{ _alloy_os[ansible_facts['os_family']].grafana.repository | default(omit) }}"
 
 # Package configuration
 alloy_package_name: "alloy"
@@ -230,8 +230,8 @@ alloy_remotecfg: {}
 # alloy_remotecfg:
 #   url: "https://fleet-management-prod-011.grafana.net/api/v1/config"
 #   poll_frequency: "30s"
-#   id: "{{ ansible_hostname }}"
-#   name: "Gateway Node {{ ansible_hostname }}"
+#   id: "{{ ansible_facts['hostname'] }}"
+#   name: "Gateway Node {{ ansible_facts['hostname'] }}"
 #   attributes:
 #     cluster: "hetzner-k3s"
 #     region: "nbg1"

--- a/roles/alloy/handlers/main.yml
+++ b/roles/alloy/handlers/main.yml
@@ -21,4 +21,4 @@
       update_cache: true
   become: true
   listen: "alloy: update apt cache"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/roles/alloy/meta/argument_specs.yml
+++ b/roles/alloy/meta/argument_specs.yml
@@ -1029,7 +1029,7 @@ argument_specs:
                     instance:
                         type: "str"
                         required: false
-                        description: "Instance identifier override (defaults to ansible_hostname)"
+                        description: "Instance identifier override (defaults to ansible_facts['hostname'])"
 
             alloy_node_exporter_metric_allowlist:
                 &alloy_node_exporter_metric_allowlist

--- a/roles/alloy/molecule/default/converge.yml
+++ b/roles/alloy/molecule/default/converge.yml
@@ -9,7 +9,7 @@
         ansible.builtin.apt:
             update_cache: true
             cache_valid_time: 3600
-        when: ansible_os_family == "Debian"
+        when: ansible_facts['os_family'] == "Debian"
 
   roles:
       - role: arillso.agent.alloy

--- a/roles/alloy/tasks/install.yml
+++ b/roles/alloy/tasks/install.yml
@@ -12,7 +12,7 @@
       update_cache: true
   become: true
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not alloy_package_only
   tags: [alloy, install, dependencies]
 
@@ -28,7 +28,7 @@
             name: grafana
             dearmor: true
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not alloy_package_only
   tags: [alloy, install, keys]
 
@@ -43,7 +43,7 @@
             filename: grafana
             update_cache: false # We'll update cache separately
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not alloy_package_only
   tags: [alloy, install, repository]
 
@@ -52,7 +52,7 @@
       name: arillso.system.packages
       tasks_from: cache
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not alloy_package_only
   tags: [alloy, install, cache]
 
@@ -72,7 +72,7 @@
       # config is in place.
       packages_services_to_restart: []
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not alloy_package_only
   tags: [alloy, install, package]
 
@@ -87,7 +87,7 @@
       enabled: true
       state: present
   when:
-      - ansible_os_family == "RedHat"
+      - ansible_facts['os_family'] == "RedHat"
       - not alloy_package_only
   tags: [alloy, install, repository]
 
@@ -100,7 +100,7 @@
   delay: 10
   until: _alloy_package_installed is succeeded
   when:
-      - ansible_os_family == "RedHat"
+      - ansible_facts['os_family'] == "RedHat"
       - not alloy_package_only
   notify: "alloy: restart alloy"
   tags: [alloy, install, package]
@@ -128,7 +128,7 @@
   delay: 10
   until: _alloy_package_installed_generic is succeeded
   when:
-      - ansible_os_family not in ["Debian", "RedHat"]
+      - ansible_facts['os_family'] not in ["Debian", "RedHat"]
       - not alloy_package_only
   notify: "alloy: restart alloy"
   tags: [alloy, install, package]

--- a/roles/alloy/templates/etc/alloy/modules/journal.j2
+++ b/roles/alloy/templates/etc/alloy/modules/journal.j2
@@ -11,7 +11,7 @@ loki.relabel "integrations_node_exporter" {
   }
   rule {
     target_label = "instance"
-    replacement  = "{{ ansible_hostname }}"
+    replacement  = "{{ ansible_facts['hostname'] }}"
   }
 }
 

--- a/roles/alloy/templates/etc/alloy/modules/node_exporter.j2
+++ b/roles/alloy/templates/etc/alloy/modules/node_exporter.j2
@@ -102,7 +102,7 @@ discovery.relabel "integrations_node_exporter" {
   // Set consistent instance label to host identifier
   rule {
     target_label = "instance"
-    replacement  = "{{ ansible_hostname }}"
+    replacement  = "{{ ansible_facts['hostname'] }}"
   }
 
   // Set job label for proper service discovery

--- a/roles/do/molecule/default/converge.yml
+++ b/roles/do/molecule/default/converge.yml
@@ -9,7 +9,7 @@
         ansible.builtin.apt:
             update_cache: true
             cache_valid_time: 3600
-        when: ansible_os_family == "Debian"
+        when: ansible_facts['os_family'] == "Debian"
 
   roles:
       - role: arillso.agent.do

--- a/roles/do/tasks/install.yml
+++ b/roles/do/tasks/install.yml
@@ -13,7 +13,7 @@
       dest: /usr/share/keyrings/digitalocean-agent.asc
       mode: "0644"
   become: true
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Add DigitalOcean repository (Debian/Ubuntu)
   ansible.builtin.apt_repository:
@@ -22,7 +22,7 @@
       update_cache: true
       filename: digitalocean-agent
   become: true
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Add DigitalOcean repository (RedHat/CentOS)
   ansible.builtin.yum_repository:
@@ -33,7 +33,7 @@
       gpgkey: "{{ do_gpg_key_url }}"
       enabled: true
   become: true
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Install DigitalOcean Agent package
   ansible.builtin.package:

--- a/roles/do/tasks/main.yml
+++ b/roles/do/tasks/main.yml
@@ -6,7 +6,7 @@
   when: do_enabled | bool
   block:
       - name: Load OS-specific variables
-        ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+        ansible.builtin.include_vars: "{{ ansible_facts['os_family'] }}.yml"
         tags:
             - do
             - install

--- a/roles/tailscale/molecule/default/converge.yml
+++ b/roles/tailscale/molecule/default/converge.yml
@@ -9,7 +9,7 @@
         ansible.builtin.apt:
             update_cache: true
             cache_valid_time: 3600
-        when: ansible_os_family == "Debian"
+        when: ansible_facts['os_family'] == "Debian"
 
   roles:
       - role: arillso.agent.tailscale

--- a/roles/tailscale/tasks/install.yml
+++ b/roles/tailscale/tasks/install.yml
@@ -14,7 +14,7 @@
             keyring: "{{ tailscale_gpg_key_path }}"
             name: tailscale
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not tailscale_package_only
   tags: [tailscale, install, keys]
 
@@ -26,12 +26,12 @@
       packages_repositories:
           - repo: >-
                 deb [signed-by={{ tailscale_gpg_key_path }}] {{ tailscale_repo_url }}
-                {{ tailscale_repo_codename | default(ansible_distribution_release) }} main
+                {{ tailscale_repo_codename | default(ansible_facts['distribution_release']) }} main
             state: present
             filename: tailscale
             update_cache: false # We'll update cache separately
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not tailscale_package_only
   tags: [tailscale, install, repository]
 
@@ -40,7 +40,7 @@
       name: arillso.system.packages
       tasks_from: cache
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not tailscale_package_only
   tags: [tailscale, install, cache]
 
@@ -56,7 +56,7 @@
       packages_retry_delay: 10
       packages_services_to_restart: ["tailscaled"]
   when:
-      - ansible_os_family == "Debian"
+      - ansible_facts['os_family'] == "Debian"
       - not tailscale_package_only
   tags: [tailscale, install, package]
 
@@ -71,7 +71,7 @@
       enabled: true
       state: present
   when:
-      - ansible_os_family == "RedHat"
+      - ansible_facts['os_family'] == "RedHat"
       - not tailscale_package_only
   tags: [tailscale, install, repository]
 
@@ -84,7 +84,7 @@
   delay: 10
   until: _tailscale_package_installed is succeeded
   when:
-      - ansible_os_family == "RedHat"
+      - ansible_facts['os_family'] == "RedHat"
       - not tailscale_package_only
   tags: [tailscale, install, package]
 
@@ -110,7 +110,7 @@
   delay: 10
   until: _tailscale_package_installed_generic is succeeded
   when:
-      - ansible_os_family not in ["Debian", "RedHat"]
+      - ansible_facts['os_family'] not in ["Debian", "RedHat"]
       - not tailscale_package_only
   tags: [tailscale, install, package]
 

--- a/roles/tailscale/tasks/main.yml
+++ b/roles/tailscale/tasks/main.yml
@@ -8,8 +8,8 @@
       - name: Display detected OS and Tailscale configuration
         ansible.builtin.debug:
             msg:
-                - "Detected OS: {{ ansible_distribution }} {{ ansible_distribution_version }}"
-                - "OS Family: {{ ansible_os_family }}"
+                - "Detected OS: {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}"
+                - "OS Family: {{ ansible_facts['os_family'] }}"
                 - "Version Key: {{ tailscale_version_key }}"
                 - "Repository URL: {{ tailscale_repo_url }}"
                 - "GPG Key URL: {{ tailscale_gpg_key_url }}"

--- a/roles/tailscale/vars/main.yml
+++ b/roles/tailscale/vars/main.yml
@@ -88,19 +88,19 @@ tailscale_fallback:
 
 # Determine version key for lookup
 tailscale_version_key: >-
-    {{- ansible_distribution_version if ansible_distribution in ['Ubuntu'] else
-        ansible_distribution_major_version if ansible_distribution in ['Debian'] else
+    {{- ansible_facts['distribution_version'] if ansible_facts['distribution'] in ['Ubuntu'] else
+        ansible_facts['distribution_major_version'] if ansible_facts['distribution'] in ['Debian'] else
         'default' -}}
 
 # Get distribution configuration
 tailscale_distro_config: >-
-    {{- tailscale_distributions.get(ansible_distribution, {}).get(tailscale_version_key) or
-        tailscale_distributions.get(ansible_distribution, {}).get('default') or
+    {{- tailscale_distributions.get(ansible_facts['distribution'], {}).get(tailscale_version_key) or
+        tailscale_distributions.get(ansible_facts['distribution'], {}).get('default') or
         tailscale_fallback -}}
 
 # Final variables used by the role
 tailscale_gpg_key_url: "{{ tailscale_distro_config.gpg_key_url | default('') }}"
 tailscale_gpg_key_path: /usr/share/keyrings/tailscale-archive-keyring.gpg
 tailscale_repo_url: "{{ tailscale_distro_config.repo_url | default('') }}"
-tailscale_repo_codename: "{{ tailscale_distro_config.codename | default(ansible_distribution_release) }}"
+tailscale_repo_codename: "{{ tailscale_distro_config.codename | default(ansible_facts['distribution_release']) }}"
 tailscale_package_only: "{{ tailscale_distro_config.package_only | default(false) }}"


### PR DESCRIPTION
## Summary

- Replaces all 44 top-level fact references across the `alloy`, `do` and `tailscale` roles with their `ansible_facts` equivalents (`ansible_os_family` → `ansible_facts['os_family']`, `ansible_hostname` → `ansible_facts['hostname']`, `ansible_distribution*` → `ansible_facts['distribution*']`). `ansible-core` deprecated the `INJECT_FACTS_AS_VARS` default of `True` and removes the automatic top-level injection in 2.24, which would leave the unprefixed names undefined and break the roles.
- `ansible_local` is deliberately left untouched in all 58 occurrences, including the two `setup: filter: ansible_local` calls. It is exempt from the deprecation and keeps its name even when read from `ansible_facts`.
- Variable names only — no logic changes, no `ansible.cfg`, no changes to lint configs or workflows. Commented-out examples and `meta/argument_specs.yml` prose are migrated too, so a later grep stays clean.

## Test plan

- [ ] `rg -c "ansible_(os_family|hostname|distribution[a-z_]*)\b" roles/ extensions/ --glob '!CHANGELOG.md'` returns no matches
- [ ] `rg -o "ansible_local\b" roles/ extensions/ --glob '!CHANGELOG.md' | wc -l` returns exactly `58`
- [ ] `yamllint roles/ extensions/` clean
- [ ] `pytest tests/unit/test_argument_spec_no_log.py` passes (loads every `roles/*/meta/argument_specs.yml`)
- [ ] CI green: `ci-ansible-collection`, `molecule-alloy`, `molecule-do`, `molecule-tailscale`, `molecule-multi-role`