### PR TITLE
fix(changelog): merge the duplicated Unreleased "Changed" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,19 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.python-version` pinning Python `3.13` (org-wide target, kept current by the
   shared `renovate-ansible` preset); consumed by the release workflow.
 
-### Changed
-
-- **All roles**: every top-level fact reference is replaced by its
-  `ansible_facts` equivalent — `ansible_os_family` becomes
-  `ansible_facts['os_family']`, `ansible_hostname` becomes
-  `ansible_facts['hostname']`, and the `ansible_distribution*` family becomes
-  `ansible_facts['distribution*']`. `ansible-core` deprecated the
-  `INJECT_FACTS_AS_VARS` default of `True` and drops the automatic top-level
-  injection in version 2.24, which would leave the unprefixed names undefined
-  and break the roles. Variable names only, no behaviour change.
-  `ansible_local` keeps its name: it is exempt from the deprecation and stays
-  at the top level even when read from `ansible_facts`.
-
 ### Removed
 
 - **DO**: the three feature flags `do_metrics_enabled`, `do_logs_enabled` and
@@ -185,6 +172,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default `true`). Anyone who set `tailscale_enabled` to control the daemon
   config must rename it to `tailscale_daemon_enabled`; leaving it in place
   no longer writes the daemon config and instead toggles the whole role.
+
+- **All roles**: every top-level fact reference is replaced by its
+  `ansible_facts` equivalent — `ansible_os_family` becomes
+  `ansible_facts['os_family']`, `ansible_hostname` becomes
+  `ansible_facts['hostname']`, and the `ansible_distribution*` family becomes
+  `ansible_facts['distribution*']`. `ansible-core` deprecated the
+  `INJECT_FACTS_AS_VARS` default of `True` and drops the automatic top-level
+  injection in version 2.24, which would leave the unprefixed names undefined
+  and break the roles. Variable names only, no behaviour change.
+  `ansible_local` keeps its name: it is exempt from the deprecation and stays
+  at the top level even when read from `ansible_facts`.
 
 - **Renovate**: the custom regex manager now also scans
   `roles/*/meta/argument_specs.yml`, and the `*_version` defaults in the


### PR DESCRIPTION
## Summary

- `[Unreleased]` had two `### Changed` headings, so `markdownlint` reported MD024 on a pristine tree and the lefthook `pre-commit` hook blocked every commit staging `CHANGELOG.md`. This is the same class of failure #132 fixed; the second heading was reintroduced in #131.
- The `ansible_facts` entry moves into the existing `### Changed` section. Indentation and wording are unchanged, and `MD024.siblings_only` stays on so real duplicates keep being reported.

## Test plan

- [x] `npx --yes -- markdownlint-cli2 $(git ls-files '*.md')` — `0 issues in 0 files` (was `1 issue in 1 file`)
- [x] `npx --yes -- prettier --check CHANGELOG.md` — passes
- [x] lefthook `pre-commit` ran clean on the commit itself
- [ ] CI green