### PR TITLE
ci: wire the Trivy config scan and SBOM generation

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -13,10 +13,29 @@ concurrency:
     cancel-in-progress: false
 
 permissions:
-    contents: read
+    contents: write # security-sbom.yml uploads the SBOM artifact
     actions: read
     pull-requests: read
+    security-events: write # security-config.yml uploads SARIF
 
 jobs:
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-14
+
+    security-config:
+        # Trivy `scan-type: config` for IaC misconfigurations. Complements the
+        # `scan-type: fs` run in ci-ansible-collection, which looks for
+        # dependency vulnerabilities instead. `scan-ansible` stays off: it only
+        # runs ansible-lint and yamllint with `|| true`, which the blocking
+        # `ci / Ansible Lint` and `ci / YAML Lint` jobs already cover.
+        uses: arillso/.github/.github/workflows/security-config.yml@2026-08-14
+        with:
+            scan-ansible: false
+
+    security-sbom:
+        # Inventory artifact, not a findings report — no overlap with the Trivy
+        # scans. No container image is built here, so scan the filesystem.
+        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-14
+        with:
+            artifact-type: filesystem
+            artifact-ref: .


### PR DESCRIPTION
## Summary

- The nightly scan only ran secret detection. `security-config.yml` adds Trivy's `config` mode for IaC misconfigurations, which the existing `fs` scan in `ci-ansible-collection` does not cover — that one looks for dependency vulnerabilities instead.
- `security-sbom.yml` produces a dependency inventory artifact from the filesystem; no container image is built here, so `artifact-type: filesystem`.
- `scan-ansible` stays off: it runs ansible-lint and yamllint with `|| true`, which the blocking `ci / Ansible Lint` and `ci / YAML Lint` jobs already cover.
- Permissions widened accordingly: `contents: write` for the SBOM artifact upload, `security-events: write` for the SARIF upload.

## Test plan

- [ ] CI green
- [ ] Trigger `Nightly Security Scan` via `workflow_dispatch` and confirm all three jobs run
- [ ] Confirm the SBOM artifact is attached to the run and the config scan reports to the Security tab