### PR TITLE
ci: scope the nightly security permissions per job

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -12,14 +12,17 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: false
 
+# Elevated scopes stay on the job that needs them. A called workflow can only
+# narrow the caller's permissions, never widen them, so each `uses:` job has to
+# carry at least what the reusable declares for itself.
 permissions:
-    contents: write # security-sbom.yml uploads the SBOM artifact
-    actions: read
-    pull-requests: read
-    security-events: write # security-config.yml uploads SARIF
+    contents: read
 
 jobs:
     security-secrets:
+        permissions:
+            contents: read
+            actions: read
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-15
 
     security-config:
@@ -28,6 +31,9 @@ jobs:
         # dependency vulnerabilities instead. `scan-ansible` stays off: it only
         # runs ansible-lint and yamllint with `|| true`, which the blocking
         # `ci / Ansible Lint` and `ci / YAML Lint` jobs already cover.
+        permissions:
+            contents: read
+            security-events: write # SARIF upload
         uses: arillso/.github/.github/workflows/security-config.yml@2026-08-15
         with:
             scan-ansible: false
@@ -35,6 +41,11 @@ jobs:
     security-sbom:
         # Inventory artifact, not a findings report — no overlap with the Trivy
         # scans. No container image is built here, so scan the filesystem.
+        #
+        # `contents: write` is what the reusable declares; its release-attaching
+        # step is gated behind `attach-to-release`, which stays off here.
+        permissions:
+            contents: write
         uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-15
         with:
             artifact-type: filesystem


### PR DESCRIPTION
## Summary

- `nightly-security.yml` declared `contents: write` and `security-events: write` at the workflow level, so every job inherited them — including `security-secrets`, which only needs `contents: read` and `actions: read`.
- Each job now carries exactly what its reusable declares for itself, and the top level drops to `contents: read`. A called workflow can only narrow the caller's permissions, never widen them, so the scopes have to sit on the calling job.
- `pull-requests: read` is dropped: none of the three reusables requests it.
- `contents: write` stays on `security-sbom` because `security-sbom.yml` declares it at job level; its `softprops/action-gh-release` step is gated behind `attach-to-release`, which is off here.

## Test plan

- [ ] CI green
- [ ] Trigger `Nightly Security Scan` via `workflow_dispatch` and confirm all three jobs still run
- [ ] Confirm the SBOM artifact upload and the SARIF upload to the Security tab still succeed under the narrowed scopes
