### PR TITLE
chore(renovate): disable updates for molecule-qemu

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,11 @@
         {
             "matchPackageNames": ["ansible-core"],
             "enabled": false
+        },
+        {
+            "description": "Flagged as abandoned by release inactivity, not deprecated. Still in use and without an equivalent replacement: molecule-qemu drives the alloy scenarios, which need a real VM because alloy must run as a stable systemd service, unreliable under the docker driver, and molecule-plugins ships no qemu driver.",
+            "matchPackageNames": ["molecule-qemu"],
+            "enabled": false
         }
     ],
     "customManagers": [


### PR DESCRIPTION
## Summary

- Renovate flags `molecule-qemu` as abandoned by release inactivity (no release since 0.5.12 on 2024-10-28). It is not deprecated and has no equivalent replacement: `molecule-plugins` ships no qemu driver, and the `alloy` role needs a real VM because alloy must run as a stable systemd service, which is unreliable under the docker driver.
- Disable updates for the package via a `packageRule` with `enabled: false`, carrying the reason in its `description`. This mirrors the rule the system collection already uses for the same dependency.
- Scoped to `molecule-qemu` only, so abandonment reporting stays active for every other dependency.

## Test plan

- [ ] `renovate-config-validator .github/renovate.json` passes
- [ ] CI green
- [ ] Renovate no longer reports `molecule-qemu` under "Abandoned Dependencies" in the dependency dashboard
