### PR TITLE
chore(repo): drop scanner configs without a consumer

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,5 +1,0 @@
----
-quiet: true
-skip-check:
-    - CKV_DOCKER_2
-    - CKV2_GHA_1

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -103,7 +103,4 @@ Fixes #(issue number)
 
 ---
 
-<!--
-Thank you for contributing to arillso.agent!
-Generated with Claude Code - https://claude.com/claude-code
--->
+<!-- Thank you for contributing to arillso.agent! -->

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,2 +1,0 @@
----
-fail-on-severity: "high"

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,4 +1,0 @@
-{
-    "threshold": 0,
-    "ignore": ["**/.ansible/**"]
-}

--- a/.kics.json
+++ b/.kics.json
@@ -1,3 +1,0 @@
-{
-    "exclude-paths": [".ansible/*"]
-}

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,5 +1,0 @@
-{
-    "retryOn429": true,
-    "retryCount": 5,
-    "aliveStatusCodes": [200, 203]
-}

--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -1,7 +1,0 @@
-{
-    "rules": [
-        {
-            "id": "@secretlint/secretlint-rule-preset-recommend"
-        }
-    ]
-}

--- a/.trivy.yaml
+++ b/.trivy.yaml
@@ -1,4 +1,0 @@
----
-scan:
-    skip-dirs:
-        - .ansible/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Developer Tooling**: the seven scanner configs `.checkov.yml`, `.grype.yaml`,
+  `.jscpd.json`, `.kics.json`, `.markdown-link-check.json`, `.secretlintrc.json`
+  and `.trivy.yaml` are gone. None of the tools they configure runs in the
+  reusable CI: checkov, grype, jscpd, kics, markdown-link-check and secretlint
+  appear in no workflow of `arillso/.github`, and `security-secrets.yml` runs
+  Gitleaks, TruffleHog and pattern detection only. Trivy does run, but reads its
+  config through the `trivy_config` input, which defaults to an empty string and
+  is passed by no workflow here — and it auto-discovers `trivy.yaml`, not the
+  dotted `.trivy.yaml`. `.gitleaks.toml` stays, because Gitleaks auto-loads it.
 - **DO**: the three feature flags `do_metrics_enabled`, `do_logs_enabled` and
   `do_insights_enabled` are gone from `defaults/main.yml` and
   `meta/argument_specs.yml`. They were declared and documented but read by no


### PR DESCRIPTION
## Summary

- Drop seven scanner config files that no tool in the reusable CI reads: `.checkov.yml`, `.grype.yaml`, `.jscpd.json`, `.kics.json`, `.markdown-link-check.json`, `.secretlintrc.json` and `.trivy.yaml`.
- Drop the tool attribution line from the pull request template, leaving the thank-you note intact.
- Record the removal under `### Removed` in the `[Unreleased]` changelog section, together with the evidence below. The historical `[1.2.0]` entry that introduced the files stays untouched.

Evidence, per tool:

- **checkov, grype, jscpd, kics, markdown-link-check, secretlint** — a code search over `arillso/.github/.github/workflows` returns 0 hits for each. `security-secrets.yml` runs exactly three scanners: Gitleaks, TruffleHog and a pattern-detection job. Since secretlint is never invoked, its auto-discovery of `.secretlintrc.json` never happens either.
- **Trivy** — does run, but takes its config through the `trivy_config` input, which defaults to an empty string and is passed by none of `pull-request.yml`, `merge.yml` or `nightly-security.yml`. Trivy also auto-discovers `trivy.yaml`, not the dotted `.trivy.yaml`, so the file was dead either way.
- **`.gitleaks.toml` is deliberately kept** — Gitleaks does run and does auto-load it.

## Test plan

- [ ] CI green, in particular `Trivy` and the four `security-secrets` jobs, which must behave exactly as before
- [ ] Markdown Lint passes on the edited pull request template and changelog

## Note

`REVIEW.md` lists secretlint among the expected security checks, which does not match what the CI actually runs. That inconsistency predates this PR — the tools were configured but never wired up — so it is left alone here rather than widening the scope.

The `checkov:skip` and `kics-scan ignore-line` comments in `roles/alloy/tasks/service.yml` now have no config alongside them. They are inert either way, so they stay untouched.
