### PR TITLE
docs(review): list scanners that actually run in CI

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -24,7 +24,7 @@ Out of scope:
 - yamllint passes
 - Unit tests (pytest) pass for plugins
 - Molecule / integration tests pass for affected roles
-- Security scans pass (gitleaks, secretlint, trivy)
+- Security scans pass (gitleaks, trufflehog, trivy)
 - `argument_specs.yml` present and complete for any new or changed role
 
 ## Severity levels


### PR DESCRIPTION
## Summary

- `REVIEW.md` listed secretlint as a required security scan, but it is not configured or invoked anywhere in the reusable workflows — reviewers were ticking off a scan that never runs.
- Replaced it with `trufflehog`, which `security-secrets.yml` does run alongside gitleaks; trivy stays (it runs in `ci-ansible-collection.yml`).
- CHANGELOG mentions of `.secretlintrc.json` are historical records of its removal and are left untouched.

## Test plan

- [ ] markdownlint and prettier pass on `REVIEW.md`
- [ ] CI green