### PR TITLE
ci: raise CI to Python 3.14 on the 2026-08-17 reusables

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,7 +24,7 @@ jobs:
         with:
             collection_namespace: arillso
             collection_name: agent
-            python_version: "3.13"
+            python_version: "3.14"
             enable_unit_tests: true
 
     security-secrets:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
     ci:
-        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -28,4 +28,4 @@ jobs:
             enable_unit_tests: true
 
     security-secrets:
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-17

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -23,7 +23,7 @@ jobs:
         permissions:
             contents: read
             actions: read
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-17
 
     security-config:
         # Trivy `scan-type: config` for IaC misconfigurations. Complements the
@@ -34,7 +34,7 @@ jobs:
         permissions:
             contents: read
             security-events: write # SARIF upload
-        uses: arillso/.github/.github/workflows/security-config.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-config.yml@2026-08-17
         with:
             scan-ansible: false
 
@@ -46,7 +46,7 @@ jobs:
         # step is gated behind `attach-to-release`, which stays off here.
         permissions:
             contents: write
-        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-08-17
         with:
             artifact-type: filesystem
             artifact-ref: .

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,7 +26,7 @@ jobs:
         with:
             collection_namespace: arillso
             collection_name: agent
-            python_version: "3.13"
+            python_version: "3.14"
             enable_unit_tests: true
 
     molecule-alloy:
@@ -41,7 +41,7 @@ jobs:
             collection_namespace: arillso
             collection_name: agent
             driver: qemu
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/alloy/molecule
             scenarios: '["default","disabled"]'
             concurrency-suffix: molecule-alloy
@@ -54,7 +54,7 @@ jobs:
             collection_namespace: arillso
             collection_name: agent
             driver: docker
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/do/molecule
             scenarios: '["default","disabled"]'
             concurrency-suffix: molecule-do
@@ -65,7 +65,7 @@ jobs:
             collection_namespace: arillso
             collection_name: agent
             driver: docker
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: roles/tailscale/molecule
             scenarios: '["default","disabled"]'
             concurrency-suffix: molecule-tailscale
@@ -79,7 +79,7 @@ jobs:
             collection_namespace: arillso
             collection_name: agent
             driver: docker
-            python_version: "3.13"
+            python_version: "3.14"
             scenarios_root: extensions/molecule
             scenarios: '["multi-role"]'
             concurrency-suffix: molecule-multi-role

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
     ci:
-        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -36,7 +36,7 @@ jobs:
         # scenarios_root is set per role and the matrix is pinned to the
         # single `default` scenario. concurrency-suffix keeps this nested
         # call out of the caller's concurrency group.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -49,7 +49,7 @@ jobs:
     molecule-do:
         # do and tailscale converge fine under the docker driver (their
         # molecule.yml uses driver: docker), so keep the default driver.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -60,7 +60,7 @@ jobs:
             concurrency-suffix: molecule-do
 
     molecule-tailscale:
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -74,7 +74,7 @@ jobs:
         # Combined scenario deploying alloy, do and tailscale on one host
         # (extensions/molecule/multi-role). Docker driver like the do/tailscale
         # default scenarios.
-        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: agent
@@ -85,9 +85,9 @@ jobs:
             concurrency-suffix: molecule-multi-role
 
     security-secrets:
-        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-17
 
     claude-review:
-        uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-08-17
         secrets:
             CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
     publish:
-        uses: arillso/.github/.github/workflows/release-ansible-collection.yml@2026-08-16
+        uses: arillso/.github/.github/workflows/release-ansible-collection.yml@2026-08-17
         with:
             collection_namespace: arillso
             collection_name: agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI**: the `arillso/.github` reusable workflows are pinned to `2026-08-17`
+  and every `python_version` input is raised from `3.13` to `3.14`. The new
+  `ci-ansible-collection` derives the controller interpreter from the ansible
+  branch (`stable-2.20` and `devel` on 3.14, older branches on 3.13) and
+  ignores the input for known branches, so sanity now covers 3.14 while the
+  input only drives the lint and molecule jobs. The supported ansible range in
+  `meta/runtime.yml` is unchanged.
+
 ## [2.0.0] - 2026-08-17
 
 ### Added


### PR DESCRIPTION
## Summary

- Bumps all 13 `arillso/.github` reusable pins from `2026-08-16` to `2026-08-17` across `pull-request.yml`, `merge.yml`, `nightly-security.yml` and `tag.yml`, and raises all 6 `python_version` inputs from `3.13` to `3.14`. Both belong in one PR: the inputs must not run against the old reusable, which hardcoded controller Python to 3.12 for `stable-2.20` and `devel`.
- The `2026-08-17` `ci-ansible-collection` derives the controller interpreter from the ansible branch (`stable-2.18`/`stable-2.19` → 3.13, `stable-2.20`/`devel` → 3.14) and ignores the input for known branches. Sanity therefore reaches 3.14 through the branch derivation, not through this input — the raised input only drives the seven lint/build jobs and the four molecule jobs.
- `ansible_versions` is deliberately not set: restricting the matrix to `stable-2.20` would test less than `meta/runtime.yml` (`>=2.18.0`) promises. `meta/runtime.yml` and `.python-version` are untouched, so the supported range is unchanged and this is not a breaking change.
- Side effect of the tag bump: `security-config` also changed between the two tags (used in `nightly-security.yml`). The other six reusables are byte-identical across the tags; they move along so the repo sits on a single tag.
- Not addressed here: `.github/renovate.json:3` still extends the preset at `#2026-08-16`, where the Python bound is `<3.14`. Renovate maintains that line itself; the `2026-08-17` preset raises it to `<3.15`.

## Test plan

- [ ] All seven lint/build jobs green on 3.14
- [ ] The four molecule jobs green on 3.14 — the real risk, since they install `molecule-qemu`, `molecule-plugins[docker]` and `pytest-ansible` under that interpreter
- [ ] Sanity matrix runs `stable-2.18`/`stable-2.19` on 3.13 and `stable-2.20` on 3.14
- [ ] Local lints green (yamllint, actionlint, prettier, markdownlint)